### PR TITLE
Tested and fixed NullPointerException when checking alternate syntax swi...

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/NonEmptyCaseWithoutBreakCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/NonEmptyCaseWithoutBreakCheck.java
@@ -25,6 +25,7 @@ import com.sonar.sslr.api.Trivia;
 import org.sonar.check.BelongsToProfile;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
+import org.sonar.php.api.PHPKeyword;
 import org.sonar.php.api.PHPPunctuator;
 import org.sonar.php.parser.PHPGrammar;
 import org.sonar.squidbridge.checks.SquidCheck;
@@ -85,6 +86,6 @@ public class NonEmptyCaseWithoutBreakCheck extends SquidCheck<Grammar> {
   }
 
   private static boolean isLastCase(AstNode caseClause) {
-    return caseClause.getNextAstNode().is(PHPPunctuator.RCURLYBRACE);
+    return caseClause.getNextAstNode().is(PHPPunctuator.RCURLYBRACE) || caseClause.getNextAstNode().is(PHPKeyword.ENDSWITCH);
   }
 }

--- a/php-checks/src/test/java/org/sonar/php/checks/NonEmptyCaseWithoutBreakCheckTest.java
+++ b/php-checks/src/test/java/org/sonar/php/checks/NonEmptyCaseWithoutBreakCheckTest.java
@@ -35,6 +35,8 @@ public class NonEmptyCaseWithoutBreakCheckTest extends CheckTest {
       .next().atLine(5).withMessage("End this switch case with an unconditional break, continue, return or throw statement.")
       .next().atLine(7)
       .next().atLine(17)
+      .next().atLine(42)
+      .next().atLine(44)
       .noMore();
   }
 }

--- a/php-checks/src/test/resources/checks/NonEmptyCaseWithoutBreakCheck.php
+++ b/php-checks/src/test/resources/checks/NonEmptyCaseWithoutBreakCheck.php
@@ -36,3 +36,17 @@ switch ($a) {
     break;
 }
 
+//Support alternate switch syntax
+switch ($a):
+  case 0:
+  case 1:     // NOK
+    doSomething();
+  case 2:     // NOK
+    __halt_compiler();
+  case 3:     // OK
+    echo "";
+    // no break intentional
+  default:    // OK
+    doSomethingElse();
+endswitch;
+


### PR DESCRIPTION
...tch statements

Attempts to parse an older internal code base exposed a fatal error when encountering alternate syntax switch statements.

http://php.net/manual/en/control-structures.alternative-syntax.php

Truncated error:

ERROR: Error during Sonar runner execution
org.sonar.runner.impl.RunnerException: Unable to execute Sonar at org.sonar.runner.impl.BatchLauncher$1.delegateExecution(BatchLauncher.java:91)
    ...
Caused by: java.lang.NullPointerException at org.sonar.php.checks.NonEmptyCaseWithoutBreakCheck.hasNoBreakComment(NonEmptyCaseWithoutBreakCheck.java:53)

Updated tests and isLastCase method to support the 'endswitch' token.
