### PR TITLE
SONARPHP-599: Initialise test suites and test cases arrays with empty lists to avoid NPE

### DIFF
--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/xml/TestSuite.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/xml/TestSuite.java
@@ -19,11 +19,15 @@
  */
 package org.sonar.plugins.php.phpunit.xml;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-
-import java.util.List;
 
 /**
  * The Class TestSuite.
@@ -79,6 +83,8 @@ public final class TestSuite {
    * */
   public TestSuite() {
     // Empty constructor is required by xstream
+    this.testSuites = new ArrayList<>();
+    this.testCases = new ArrayList<>();
   }
 
   /**
@@ -100,8 +106,8 @@ public final class TestSuite {
     this.tests = tests;
     this.assertions = assertions;
     this.time = time;
-    this.testSuites = testSuites;
-    this.testCases = testCases;
+    this.testSuites = CollectionUtils.isEmpty(testSuites) ? Collections.<TestSuite>emptyList() : testSuites;
+    this.testCases = CollectionUtils.isEmpty(testCases) ? Collections.<TestCase>emptyList() : testCases;
   }
 
   /**

--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/xml/TestSuites.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/xml/TestSuites.java
@@ -43,6 +43,7 @@ public final class TestSuites {
    * */
   public TestSuites() {
     // Empty constructor is required by xstream
+    this.testSuites = new ArrayList<>();
   }
 
   /**
@@ -69,9 +70,6 @@ public final class TestSuites {
    * @param testSuite the test suite
    */
   public void addTestSuite(final TestSuite testSuite) {
-    if (testSuites == null) {
-      testSuites = new ArrayList<>();
-    }
     testSuites.add(testSuite);
   }
 }

--- a/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/PhpUnitResultParserTest.java
+++ b/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/PhpUnitResultParserTest.java
@@ -117,6 +117,15 @@ public class PhpUnitResultParserTest {
     verify(context).saveMeasure(bananaFile, CoreMetrics.TEST_EXECUTION_TIME, 570.0);
   }
 
+  /**
+   * Should not fail with empty test suite.
+   */
+  @Test
+  public void shouldNotFailWithEmptyTestSuite() {
+    parser.parse(TestUtils.getResource(MockUtils.PHPUNIT_REPORT_DIR + "phpunit-with-empty-testsuite.xml"));
+    verify(context, never()).saveMeasure(any(org.sonar.api.resources.File.class), any(Metric.class), anyDouble());
+  }
+
   @Test(expected = SonarException.class)
   public void testGetTestSuitesWithUnexistingFile() throws Exception {
     parser.getTestSuites(new File("target/unexistingFile.xml"));

--- a/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit-with-empty-testsuite.xml
+++ b/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit-with-empty-testsuite.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<testsuites/>


### PR DESCRIPTION
Fix for https://jira.sonarsource.com/browse/SONARPHP-599.

When empty/null lists are given, a blank immutable list is created instead. One may prefer to have a mutable one, so feel free to change it if necessary.

Unit test added a passing locally.