### PR TITLE
SOANRPHP-619 FunctionSpacingCheck: exception on non-lowercase "internal functional function" call without parenthesis

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/FormattingStandardCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/FormattingStandardCheck.java
@@ -203,7 +203,7 @@ public class FormattingStandardCheck extends PHPVisitorCheck {
   );
 
   public boolean isInternalFunction(ExpressionTree callee) {
-    String calleeString = callee.toString();
+    String calleeString = callee.toString().toLowerCase();
     return INTERNAL_FUNCTIONS.contains(calleeString);
   }
 

--- a/php-checks/src/test/resources/checks/formattingCheck/FunctionSpacingCheck.php
+++ b/php-checks/src/test/resources/checks/formattingCheck/FunctionSpacingCheck.php
@@ -32,3 +32,4 @@ foo->
   bar($a,$b);    // NOK
 
 echo "la" , "lala";    // OK - internal
+Echo "la" , "lala";    // OK - internal


### PR DESCRIPTION
Fix for https://jira.sonarsource.com/browse/SONARPHP-619

Since php allows for case insensitive internal function calls "Echo" or even "EcHo" should be recognized as internal functions. Converting the callee string to lowercase accomplishes this, because PHPKeyword is defined in lower case.