### PR TITLE
Update SSLR to 1.22

### DIFF
--- a/php-frontend/pom.xml
+++ b/php-frontend/pom.xml
@@ -26,6 +26,10 @@
       <artifactId>sslr-squid-bridge</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sonarsource.sslr</groupId>
       <artifactId>sslr-testing-harness</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <version.slf4j>1.6.2</version.slf4j>
     <version.sonar>6.2</version.sonar>
     <version.sonar-orchestrator>3.13</version.sonar-orchestrator>
-    <version.sslr>1.21</version.sslr>
+    <version.sslr>1.22</version.sslr>
     <version.sslr-squid-bridge>2.6.1</version.sslr-squid-bridge>
     <version.xstream>1.3.1</version.xstream>
     <version.sonarlint>2.5.0.36</version.sonarlint>
@@ -153,6 +153,11 @@
             <artifactId>jcl-over-slf4j</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>10.0.1</version>
       </dependency>
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>


### PR DESCRIPTION
Also adds explicit dependency on Guava, because SSLR doesn't depend on
Guava anymore, while this project depends.