### PR TITLE
Revert "SONARPHP-735 Parse array initializer as primary expression (#253)"

### DIFF
--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
@@ -1404,7 +1404,6 @@ public class PHPGrammar {
         f.newStaticIdentifier(b.token(STATIC)),
         NAMESPACE_NAME(),
         VARIABLE_WITHOUT_OBJECTS(),
-        ARRAY_INITIALIZER(),
         PARENTHESIZED_EXPRESSION()));
   }
 
@@ -1644,10 +1643,10 @@ public class PHPGrammar {
     return b.<ExpressionTree>nonterminal(PHPLexicalGrammar.POSTFIX_EXPR).is(
       f.postfixExpression(
         b.firstOf(
+          f.combinedScalarOffset(ARRAY_INITIALIZER(), b.zeroOrMore(DIMENSIONAL_OFFSET())),
           FUNCTION_EXPRESSION(),
           COMMON_SCALAR(),
           MEMBER_EXPRESSION(),
-          f.combinedScalarOffset(ARRAY_INITIALIZER(), b.zeroOrMore(DIMENSIONAL_OFFSET())),
           NEW_EXPRESSION(),
           EXIT_EXPRESSION(),
           LIST_EXPRESSION_ASSIGNMENT(),

--- a/php-frontend/src/test/java/org/sonar/php/parser/expression/MemberExpressionTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/expression/MemberExpressionTest.java
@@ -95,9 +95,6 @@ public class MemberExpressionTest {
     .matches("f()->$a")
     .matches("$a->{'b'}")
 
-    .matches("A::class")
-    .matches("A::fun()")
-    .matches("[A::fun, $arg]()")
-    ;
+    .matches("A::class");
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/parser/expression/PrimaryExpressionTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/expression/PrimaryExpressionTest.java
@@ -31,7 +31,6 @@ public class PrimaryExpressionTest {
     assertThat(PHPLexicalGrammar.PRIMARY_EXPRESSION)
       .matches("static")
       .matches("a")
-      .matches("[a, b]")
       .matches("$a")
       .matches("($a)");
   }

--- a/php-frontend/src/test/java/org/sonar/php/parser/statement/StatementTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/statement/StatementTest.java
@@ -43,9 +43,7 @@ public class StatementTest {
     .matches("global $a;")
     .matches("echo \"Hi\";")
     .matches("unset($a);")
-    .matches("$var = function () {};")
-    .matches("[A::fun, $arg]();")
-    ;
+    .matches("$var = function () {};");
   }
 
   @Test


### PR DESCRIPTION
This reverts commit 55b7bad0f7867dd1049a74b828751c73da6b1770.