### PR TITLE
Fix PSR-2 (2.3) 

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/TrailingWhitespaceCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/TrailingWhitespaceCheck.java
@@ -34,7 +34,7 @@ public class TrailingWhitespaceCheck extends PHPVisitorCheck {
   public static final String KEY = "S1131";
   private static final String MESSAGE = "Remove the useless trailing whitespaces at the end of this line.";
 
-  private static final Pattern WHITESPACE_PATTERN = Pattern.compile("[" + LexicalConstant.WHITESPACE + "]");
+  private static final Pattern WHITESPACE_PATTERN = Pattern.compile("[^" + LexicalConstant.WHITESPACE + "]+[" + LexicalConstant.WHITESPACE + "]+$");
 
   @Override
   public void visitCompilationUnit(CompilationUnitTree tree) {
@@ -51,7 +51,7 @@ public class TrailingWhitespaceCheck extends PHPVisitorCheck {
   }
 
   private static boolean test(String line) {
-    return line.length() > 0 && WHITESPACE_PATTERN.matcher(line.subSequence(line.length() - 1, line.length())).matches();
+    return line.length() > 0 && WHITESPACE_PATTERN.matcher(line).find();
   }
 
 }

--- a/php-checks/src/test/resources/checks/TrailingWhitespaceCheck.php
+++ b/php-checks/src/test/resources/checks/TrailingWhitespaceCheck.php
@@ -3,3 +3,6 @@
 // next line is empty and OK
 
 // this line has trailing whitespace: 
+
+// next line contains only spaces and is ok
+    


### PR DESCRIPTION
The current pattern matches blank lines (lines containing only whitespaces) while psr-2 states that:

There MUST NOT be trailing whitespace at the end of non-blank lines.

http://www.php-fig.org/psr/psr-2/#23-lines