### PR TITLE
update xstream version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <version.sonar-orchestrator>3.14.0.887</version.sonar-orchestrator>
     <version.sslr>1.22</version.sslr>
     <version.sslr-squid-bridge>2.6.1</version.sslr-squid-bridge>
-    <version.xstream>1.3.1</version.xstream>
+    <version.xstream>1.4.10</version.xstream>
     <version.guava>18.0</version.guava>
     <version.sonarlint>3.0.0.1140</version.sonarlint>
     <version.analyzer-commons>1.3.0.116</version.analyzer-commons>


### PR DESCRIPTION
 This installs xstream version 1.3.1. There is security vulnerability with this version and the CVS score is 7.5 https://nvd.nist.gov/vuln/detail/CVE-2017-7957. To remove this vulnerability, xstream package needs to be upgraded to 1.4.10. I have updated the pom.xml with the fix.