### PR TITLE
SONARPHP-766 Fix FP for UseOfEmptyReturnValueCheck on "new" operator

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/UseOfEmptyReturnValueCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/UseOfEmptyReturnValueCheck.java
@@ -388,6 +388,9 @@ public class UseOfEmptyReturnValueCheck extends PHPVisitorCheck {
   private static boolean parentUseValue(Tree child) {
     Tree parent = child.getParent();
     Preconditions.checkNotNull(parent);
+    if (parent.is(Tree.Kind.NEW_EXPRESSION)) {
+    	  return false;
+    }
     if (parent.is(Tree.Kind.PARENTHESISED_EXPRESSION, Tree.Kind.ERROR_CONTROL)) {
       return parentUseValue(parent);
     } else if (parent.is(Tree.Kind.EXPRESSION_STATEMENT)) {

--- a/php-checks/src/test/resources/checks/UseOfEmptyReturnValueCheck.php
+++ b/php-checks/src/test/resources/checks/UseOfEmptyReturnValueCheck.php
@@ -84,3 +84,5 @@ $converter = new UConverter();
 $a = $converter->setSourceEncoding("UTF8"); // SONARPHP-739 False-negative due to lack of semantic on function call
 
 $a = hex2bin("AF");
+
+$header = new Header($preseller);


### PR DESCRIPTION
IMHO there is al false positive for rule S3699 when using the `new` keyword to instantiate a new object, e.g.:
 
`$header = new Header($preseller);`

I added a test and also a fix for this issue. Please review. Please let me know if I also need to create a ticket or something.

Thanks a lot.