### PR TITLE
Correct null pointer caused by missing time attribute.

### DIFF
--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/JUnitLogParserForPhpUnit.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/JUnitLogParserForPhpUnit.java
@@ -80,7 +80,12 @@ public class JUnitLogParserForPhpUnit {
   private static TestSuite processTestSuite(SMInputCursor cursor) throws XMLStreamException {
     String name = cursor.getAttrValue("name");
     String file = cursor.getAttrValue("file");
-    double time = Double.parseDouble(cursor.getAttrValue("time"));
+    double time = 0;
+    try {
+      time = Double.parseDouble(cursor.getAttrValue("time"));
+    } catch (NullPointerException | NumberFormatException ex) {
+      // ignore
+    }
 
     List<TestCase> testCases = new ArrayList<>();
     List<TestSuite> nestedSuites = new ArrayList<>();

--- a/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/JUnitLogParserForPhpUnitTest.java
+++ b/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/JUnitLogParserForPhpUnitTest.java
@@ -43,6 +43,13 @@ public class JUnitLogParserForPhpUnitTest {
     assertThat(suites).isEqualTo(new TestSuites(Collections.emptyList()));
   }
 
+  @Test
+  public void shouldParseTestSuitesWithoutTime() {
+    final TestSuites suites = parser.parse(new File("src/test/resources/" + PhpTestUtils.PHPUNIT_REPORT_DIR + "phpunit-junit-report-no-time.xml"));
+    assertThat(suites).isNotNull();
+    assertThat(suites).isNotEqualTo(new TestSuites(Collections.emptyList()));
+  }
+
   @Test(expected = IllegalStateException.class)
   public void shouldThrowAnExceptionWhenReportIsInvalid() {
     parser.parse(new File("src/test/resources/" + PhpTestUtils.PHPUNIT_REPORT_DIR + "phpunit-invalid.xml"));

--- a/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit-junit-report-no-time.xml
+++ b/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit-junit-report-no-time.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+<!-- Paths have been changed from absolute to relative for testability purpose -->
+<testsuite name="DaTestSuite" tests="10" assertions="8" errors="1" failures="1" skipped="2">
+    <testsuite name="App2Test" file="src/App2Test.php" tests="1" assertions="1" errors="0" failures="0" skipped="0">
+        <testcase name="testCanBeUsedAsString" class="App2Test" file="src/App2Test.php" line="26" assertions="1"/>
+    </testsuite>
+</testsuite>
+</testsuites>


### PR DESCRIPTION
If `testsuite` element is missing the `time` attribute, it causes a `NullPointerException`

How I found this issue can be found here: https://github.com/Codeception/Codeception/issues/5004#issuecomment-419493813

Stacktrace:

```
12:21:32.428 ERROR: Error during SonarQube Scanner execution
java.lang.NullPointerException
	at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:1838)
	at sun.misc.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
	at java.lang.Double.parseDouble(Double.java:538)
	at org.sonar.plugins.php.phpunit.JUnitLogParserForPhpUnit.processTestSuite(JUnitLogParserForPhpUnit.java:83)
	at org.sonar.plugins.php.phpunit.JUnitLogParserForPhpUnit.processTestSuite(JUnitLogParserForPhpUnit.java:91)
	at org.sonar.plugins.php.phpunit.JUnitLogParserForPhpUnit.processRoot(JUnitLogParserForPhpUnit.java:75)
	at org.sonar.plugins.php.phpunit.JUnitLogParserForPhpUnit.parse(JUnitLogParserForPhpUnit.java:48)
	at org.sonar.plugins.php.phpunit.TestResultImporter.importReport(TestResultImporter.java:37)
	at org.sonar.plugins.php.phpunit.SingleFileReportImporter.lambda$importReport$0(SingleFileReportImporter.java:54)
	at java.util.Optional.ifPresent(Optional.java:159)
	at org.sonar.plugins.php.phpunit.SingleFileReportImporter.importReport(SingleFileReportImporter.java:52)
	at org.sonar.plugins.php.phpunit.SingleFileReportImporter.importReport(SingleFileReportImporter.java:44)
	at org.sonar.plugins.php.PHPSensor.processTestsAndCoverage(PHPSensor.java:136)
	at org.sonar.plugins.php.PHPSensor.execute(PHPSensor.java:124)
	at org.sonar.scanner.sensor.SensorWrapper.analyse(SensorWrapper.java:53)
	at org.sonar.scanner.phases.SensorsExecutor.executeSensor(SensorsExecutor.java:88)
	at org.sonar.scanner.phases.SensorsExecutor.execute(SensorsExecutor.java:82)
	at org.sonar.scanner.phases.SensorsExecutor.execute(SensorsExecutor.java:68)
	at org.sonar.scanner.phases.AbstractPhaseExecutor.execute(AbstractPhaseExecutor.java:88)
	at org.sonar.scanner.scan.ModuleScanContainer.doAfterStart(ModuleScanContainer.java:180)
	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:135)
	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:121)
	at org.sonar.scanner.scan.ProjectScanContainer.scan(ProjectScanContainer.java:302)
	at org.sonar.scanner.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:297)
	at org.sonar.scanner.scan.ProjectScanContainer.doAfterStart(ProjectScanContainer.java:271)
	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:135)
	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:121)
	at org.sonar.scanner.task.ScanTask.execute(ScanTask.java:48)
	at org.sonar.scanner.task.TaskContainer.doAfterStart(TaskContainer.java:84)
	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:135)
	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:121)
	at org.sonar.scanner.bootstrap.GlobalContainer.executeTask(GlobalContainer.java:121)
	at org.sonar.batch.bootstrapper.Batch.doExecuteTask(Batch.java:116)
	at org.sonar.batch.bootstrapper.Batch.execute(Batch.java:71)
	at org.sonarsource.scanner.api.internal.batch.BatchIsolatedLauncher.execute(BatchIsolatedLauncher.java:46)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.sonarsource.scanner.api.internal.IsolatedLauncherProxy.invoke(IsolatedLauncherProxy.java:60)
	at com.sun.proxy.$Proxy0.execute(Unknown Source)
	at org.sonarsource.scanner.api.EmbeddedScanner.doExecute(EmbeddedScanner.java:171)
	at org.sonarsource.scanner.api.EmbeddedScanner.execute(EmbeddedScanner.java:128)
	at org.sonarsource.scanner.cli.Main.execute(Main.java:111)
	at org.sonarsource.scanner.cli.Main.execute(Main.java:75)
	at org.sonarsource.scanner.cli.Main.main(Main.java:61)
```