### PR TITLE
SONARPHP-953 [Performance] Several minutes is spent in LexicalConstant.NUMERIC_LITERAL regular expression when parsing a file

### DIFF
--- a/php-frontend/src/main/java/org/sonar/php/parser/LexicalConstant.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/LexicalConstant.java
@@ -26,9 +26,9 @@ public class LexicalConstant {
    */
   public static final String PHP_OPENING_TAG = "(?i)(?:<\\?(?:php|=|)|<%)";
   // we use "[\s\S]" instead of "." as the dot doesn't consume line endings
-  private static final String ANY_CHAR_BUT_START_TAG = "((?!" + PHP_OPENING_TAG + ")[\\s\\S])";
+  private static final String ANY_CHAR_BUT_START_TAG = "(?:(?!" + PHP_OPENING_TAG + ")[\\s\\S])";
   public static final String PHP_CLOSING_TAG = "(?:[\\?%]>)";
-  public static final String PHP_START_TAG = ANY_CHAR_BUT_START_TAG + "*+(" + PHP_OPENING_TAG + ")";
+  public static final String PHP_START_TAG = ANY_CHAR_BUT_START_TAG + "*+(?:" + PHP_OPENING_TAG + ")";
   public static final String PHP_END_TAG = PHP_CLOSING_TAG + PHP_START_TAG + "?+";
   public static final String ANYTHING_BUT_START_TAG = ANY_CHAR_BUT_START_TAG + "++";
 
@@ -51,7 +51,7 @@ public class LexicalConstant {
    */
   private static final String IDENTIFIER_START = "[a-zA-Z_\\x7f-\\xff]";
   public static final String IDENTIFIER_PART = "[" + IDENTIFIER_START + "[0-9]]";
-  public static final String IDENTIFIER = IDENTIFIER_START + IDENTIFIER_PART + "*";
+  public static final String IDENTIFIER = IDENTIFIER_START + IDENTIFIER_PART + "*+";
 
   private static final String VAR_IDENTIFIER_START = "\\$";
   public static final String VAR_IDENTIFIER = VAR_IDENTIFIER_START + IDENTIFIER;
@@ -109,24 +109,24 @@ public class LexicalConstant {
    * Heredoc / Nowdoc
    */
   public static final String NEW_LINE = "(?:\r\n?+|\n)";
-  public static final String HEREDOC = "(?s)(<<<[ \t\u000B\f]*\"?([^\r\n'\"]++)\"?" + NEW_LINE + ")(?:(.*?)" + NEW_LINE + ")?[ \t]*+\\2(?!" + IDENTIFIER_PART + ")";
-  public static final String NOWDOC = "(?s)<<<[ \t\u000B\f]*'([^\r\n'\"]++)'" + NEW_LINE + "(?:.*?" + NEW_LINE + ")?[ \t]*+\\1(?!" + IDENTIFIER_PART + ")";
+  public static final String HEREDOC = "(?s)(<<<[ \t\u000B\f]*+\"?([^\r\n'\"]++)\"?" + NEW_LINE + ")(?:(.*?)" + NEW_LINE + ")?[ \t]*+\\2(?!" + IDENTIFIER_PART + ")";
+  public static final String NOWDOC = "(?s)<<<[ \t\u000B\f]*+'([^\r\n'\"]++)'" + NEW_LINE + "(?:.*?" + NEW_LINE + ")?[ \t]*+\\1(?!" + IDENTIFIER_PART + ")";
 
   /**
    * String
    */
   public static final String STRING_LITERAL = "(?:"
     + "\"" + STRING_WITH_ENCAPS_VAR_CHARACTERS + "?+" + "\""
-    + "|'([^'\\\\]*+(\\\\[\\s\\S])?+)*+'"
+    + "|'(?:[^'\\\\]*+(?:\\\\[\\s\\S])?+)*+'"
     + ")";
 
   /**
    * Integer
    */
-  private static final String DECIMAL = "[1-9][0-9]*+(_[0-9]++)*+";
-  private static final String HEXADECIMAL = "0[xX][0-9a-fA-F]++(_[0-9a-fA-F]++)*+";
-  private static final String OCTAL = "0[0-7]*+(_[0-7]++)*+";
-  private static final String BINARY = "0[bB][01]++(_[01]++)*+";
+  private static final String DECIMAL = "[1-9][0-9]*+(?:_[0-9]++)*+";
+  private static final String HEXADECIMAL = "0[xX][0-9a-fA-F]++(?:_[0-9a-fA-F]++)*+";
+  private static final String OCTAL = "0[0-7]*+(?:_[0-7]++)*+";
+  private static final String BINARY = "0[bB][01]++(?:_[01]++)*+";
   private static final String INTEGER_LITERAL = HEXADECIMAL
     + "|" + BINARY
     + "|" + OCTAL
@@ -135,10 +135,10 @@ public class LexicalConstant {
   /**
    * Floating point
    */
-  private static final String LNUM = "[0-9]+(_[0-9]+)*";
-  private static final String DNUM = "(([0-9]+(_[0-9]+)*)*[\\.]" + LNUM + ")"
-    + "|(" + LNUM + "[\\.]([0-9]+(_[0-9]+)*)*)";
-  private static final String EXPONENT_DNUM = "((" + LNUM + "|" + DNUM + ")[eE][+-]?" + LNUM + ")";
+  private static final String LNUM = "[0-9]++(?:_[0-9]++)*+";
+  private static final String DNUM = "(?:(?:[0-9]++(?:_[0-9]++)*+)*+[\\.]" + LNUM + ")"
+    + "|(?:" + LNUM + "[\\.](?:[0-9]++(?:_[0-9]++)*+)*+)";
+  private static final String EXPONENT_DNUM = "(?:(?:" + LNUM + "|" + DNUM + ")[eE][+-]?" + LNUM + ")";
 
   /**
    * Numeric Literal


### PR DESCRIPTION
After this change, github.com/Dolibarr/dolibarr/htdocs/includes/phpoffice/phpexcel/Classes/PHPExcel/Calculation/Statistical.php can be parsed in less than one second instead of several minutes.