### PR TITLE
Use ${revision} and flatten maven plugin to set artifact version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,7 +64,7 @@ plugin_qa_task:
     - git submodule update --init
   qa_script:
     - source cirrus-env QA
-    - source set_maven_build_version $BUILD_NUMBER
+    - source .cirrus/set_maven_build_version $BUILD_NUMBER
     - cd its/plugin
     - mvn verify -Drevision=${PROJECT_VERSION} -Dsonar.runtimeVersion=${SQ_VERSION} -Dmaven.test.redirectTestOutputToFile=false -B -e -V
   cleanup_before_cache_script: cleanup_maven_repository
@@ -85,7 +85,7 @@ ruling_task:
     - git submodule update --init
   ruling_script:
     - source cirrus-env QA
-    - source set_maven_build_version $BUILD_NUMBER
+    - source .cirrus/set_maven_build_version $BUILD_NUMBER
     - cd its/ruling
     - mvn verify -Drevision=${PROJECT_VERSION} -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -B -e -V
   cleanup_before_cache_script: cleanup_maven_repository
@@ -109,7 +109,7 @@ promote_task:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   script:
     - source cirrus-env PROMOTE
-    - source set_maven_build_version $BUILD_NUMBER
+    - source .cirrus/set_maven_build_version $BUILD_NUMBER
     - curl -sfSL -H "Authorization: Bearer $GCF_ACCESS_TOKEN" "$PROMOTE_URL/$GITHUB_REPO/$GITHUB_BRANCH/$BUILD_NUMBER/$PULL_REQUEST"
     - burgr-notify-promotion
   cleanup_before_cache_script: cleanup_maven_repository

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,7 @@ env:
   BURGR_URL: ENCRYPTED[!c7e294da94762d7bac144abef6310c5db300c95979daed4454ca977776bfd5edeb557e1237e3aa8ed722336243af2d78!]
   BURGR_USERNAME: ENCRYPTED[!b29ddc7610116de511e74bec9a93ad9b8a20ac217a0852e94a96d0066e6e822b95e7bc1fe152afb707f16b70605fddd3!]
   BURGR_PASSWORD: ENCRYPTED[!83e130718e92b8c9de7c5226355f730e55fb46e45869149a9223e724bb99656878ef9684c5f8cfef434aa716e87f4cf2!]
+  PATH: ${CIRRUS_WORKING_DIR}/.cirrus:${PATH}
 
 container_definition: &CONTAINER_DEFINITION
   image: gcr.io/language-team/base:latest
@@ -40,7 +41,7 @@ build_task:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository 
   build_script:
     - source cirrus-env BUILD
-    - regular_mvn_build_deploy_analyze
+    - .cirrus/regular_mvn_build_deploy_analyze
   cleanup_before_cache_script: cleanup_maven_repository
 
 plugin_qa_task:
@@ -65,7 +66,7 @@ plugin_qa_task:
     - source cirrus-env QA
     - source set_maven_build_version $BUILD_NUMBER
     - cd its/plugin
-    - mvn verify -Dsonar.runtimeVersion=${SQ_VERSION} -Dmaven.test.redirectTestOutputToFile=false -B -e -V
+    - mvn verify -Drevision=${PROJECT_VERSION} -Dsonar.runtimeVersion=${SQ_VERSION} -Dmaven.test.redirectTestOutputToFile=false -B -e -V
   cleanup_before_cache_script: cleanup_maven_repository
 
 ruling_task:
@@ -86,7 +87,7 @@ ruling_task:
     - source cirrus-env QA
     - source set_maven_build_version $BUILD_NUMBER
     - cd its/ruling
-    - mvn verify -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -B -e -V
+    - mvn verify -Drevision=${PROJECT_VERSION} -Dsonar.runtimeVersion=LATEST_RELEASE -Dmaven.test.redirectTestOutputToFile=false -B -e -V
   cleanup_before_cache_script: cleanup_maven_repository
  
 promote_task:

--- a/.cirrus/regular_mvn_build_deploy_analyze
+++ b/.cirrus/regular_mvn_build_deploy_analyze
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Regular way to build a SonarSource Maven project.
+# Requires the environment variables:
+# - SONAR_HOST_URL: URL of SonarQube server
+# - SONAR_TOKEN: access token to send analysis reports to $SONAR_HOST_URL
+# - GITHUB_TOKEN: access token to send analysis of pull requests to GibHub
+# - ARTIFACTORY_URL: URL to Artifactory repository
+# - ARTIFACTORY_DEPLOY_REPO: name of deployment repository
+# - ARTIFACTORY_DEPLOY_USERNAME: login to deploy to $ARTIFACTORY_DEPLOY_REPO
+# - ARTIFACTORY_DEPLOY_PASSWORD: password to deploy to $ARTIFACTORY_DEPLOY_REPO
+
+set -euo pipefail
+
+# Fetch all commit history so that SonarQube has exact blame information
+# for issue auto-assignment
+# This command can fail with "fatal: --unshallow on a complete repository does not make sense"
+# if there are not enough commits in the Git repository 
+# For this reason errors are ignored with "|| true"
+git fetch --unshallow || true
+
+# fetch references from github for PR analysis
+if [ ! -z "${GITHUB_BASE_BRANCH}" ]; then
+	git fetch origin ${GITHUB_BASE_BRANCH}
+fi
+
+# PIPELINE_ID is used by burgr to identify stages of the pipeline
+if [ -z "$PIPELINE_ID" ]; then
+  $PIPELINE_ID=$BUILD_NUMBER
+fi
+
+if [ "${GITHUB_BRANCH}" == "master" ] && [ "$PULL_REQUEST" == "false" ]; then
+  echo '======= Build, deploy and analyze master'
+
+  git fetch origin ${GITHUB_BRANCH}
+
+  # Analyze with SNAPSHOT version as long as SQ does not correctly handle
+  # purge of release data
+  CURRENT_VERSION=`maven_expression "project.version"`
+
+  . set_maven_build_version $BUILD_NUMBER
+
+  export MAVEN_OPTS="-Xmx1536m -Xms128m"
+  mvn deploy sonar:sonar \
+      -Pcoverage,deploy-sonarsource,release \
+      -Drevision=${PROJECT_VERSION} \
+      -Dmaven.test.redirectTestOutputToFile=false \
+      -Dsonar.host.url=$SONAR_HOST_URL \
+      -Dsonar.login=$SONAR_TOKEN \
+      -Dsonar.projectVersion=$CURRENT_VERSION \
+      -Dsonar.analysis.buildNumber=$BUILD_NUMBER \
+      -Dsonar.analysis.pipeline=$PIPELINE_ID \
+      -Dsonar.analysis.sha1=$GIT_SHA1  \
+      -Dsonar.analysis.repository=$GITHUB_REPO \
+      -B -e -V $*
+
+elif [[ "${GITHUB_BRANCH}" == "branch-"* ]] && [ "$PULL_REQUEST" == "false" ]; then
+  # analyze maintenance branches as long-living branches
+
+  # Fetch all commit history so that SonarQube has exact blame information
+  # for issue auto-assignment
+  # This command can fail with "fatal: --unshallow on a complete repository does not make sense"
+  # if there are not enough commits in the Git repository 
+  # For this reason errors are ignored with "|| true"
+  git fetch --unshallow || true
+
+  git fetch origin ${GITHUB_BRANCH}
+  
+  export MAVEN_OPTS="-Xmx1536m -Xms128m"
+
+  # get current version from pom
+  CURRENT_VERSION=`maven_expression "project.version"`
+
+  if [[ $CURRENT_VERSION =~ "-SNAPSHOT" ]]; then
+    echo "======= Found SNAPSHOT version ======="
+    # Do not deploy a SNAPSHOT version but the release version related to this build
+    . set_maven_build_version $BUILD_NUMBER
+    mvn deploy \
+      -Drevision=${PROJECT_VERSION} \
+      -Pcoverage,deploy-sonarsource,release \
+      -B -e -V $*
+  else
+    echo "======= Found RELEASE version ======="
+    mvn deploy \
+      -Drevision=${PROJECT_VERSION} \
+      -Pcoverage,deploy-sonarsource,release \
+      -B -e -V $*
+  fi
+
+  mvn sonar:sonar \
+      -Drevision=${PROJECT_VERSION} \
+      -Dsonar.host.url=$SONAR_HOST_URL \
+      -Dsonar.login=$SONAR_TOKEN \
+      -Dsonar.branch.name=$GITHUB_BRANCH \
+      -Dsonar.analysis.buildNumber=$BUILD_NUMBER \
+      -Dsonar.analysis.pipeline=$PIPELINE_ID \
+      -Dsonar.analysis.sha1=$GIT_SHA1  \
+      -Dsonar.analysis.repository=$GITHUB_REPO
+
+
+elif [ "$PULL_REQUEST" != "false" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+  echo '======= Build and analyze pull request'
+
+  # Do not deploy a SNAPSHOT version but the release version related to this build and PR
+  . set_maven_build_version $BUILD_NUMBER
+
+  # No need for Maven phase "install" as the generated JAR files do not need to be installed
+  # in Maven local repository. Phase "verify" is enough.
+
+  export MAVEN_OPTS="-Xmx1G -Xms128m"
+  if [ "${DEPLOY_PULL_REQUEST:-}" == "true" ]; then
+    echo '======= with deploy'
+    mvn deploy sonar:sonar \
+      -Pcoverage,deploy-sonarsource \
+      -Drevision=${PROJECT_VERSION} \
+      -Dmaven.test.redirectTestOutputToFile=false \
+      -Dsonar.host.url=$SONAR_HOST_URL \
+      -Dsonar.login=$SONAR_TOKEN \
+      -Dsonar.analysis.buildNumber=$BUILD_NUMBER \
+      -Dsonar.analysis.pipeline=$PIPELINE_ID \
+      -Dsonar.analysis.sha1=$GIT_SHA1  \
+      -Dsonar.analysis.repository=$GITHUB_REPO \
+      -Dsonar.analysis.prNumber=$PULL_REQUEST \
+      -Dsonar.pullrequest.branch=$GITHUB_BRANCH \
+      -Dsonar.pullrequest.base=$GITHUB_BASE_BRANCH \
+      -Dsonar.pullrequest.key=$PULL_REQUEST \
+      -B -e -V $*
+  else
+    echo '======= no deploy'
+    mvn verify sonar:sonar \
+      -Pcoverage \
+      -Drevision=${PROJECT_VERSION} \
+      -Dmaven.test.redirectTestOutputToFile=false \
+      -Dsonar.host.url=$SONAR_HOST_URL \
+      -Dsonar.login=$SONAR_TOKEN \
+      -Dsonar.analysis.buildNumber=$BUILD_NUMBER \
+      -Dsonar.analysis.pipeline=$PIPELINE_ID \
+      -Dsonar.analysis.sha1=$PULL_REQUEST_SHA  \
+      -Dsonar.analysis.repository=$GITHUB_REPO \
+      -Dsonar.analysis.prNumber=$PULL_REQUEST \
+      -Dsonar.pullrequest.branch=$GITHUB_BRANCH \
+      -Dsonar.pullrequest.base=$GITHUB_BASE_BRANCH \
+      -Dsonar.pullrequest.key=$PULL_REQUEST \
+      -B -e -V $*
+  fi
+
+elif [[ "$GITHUB_BRANCH" == "dogfood-on-"* ]] && [ "$PULL_REQUEST" == "false" ]; then
+  echo '======= Build dogfood branch'
+
+    # get current version from pom
+  CURRENT_VERSION=`maven_expression "project.version"`
+
+  . set_maven_build_version $BUILD_NUMBER  
+
+  mvn deploy \
+    -Pdeploy-sonarsource,release \
+    -Drevision=${PROJECT_VERSION} \
+    -B -e -V $*
+
+elif [[ "$GITHUB_BRANCH" == "feature/long/"* ]] && [ "$PULL_REQUEST" == "false" ]; then
+  echo '======= Build and analyze long lived feature branch'
+    
+  mvn verify sonar:sonar \
+    -Pcoverage \
+    -Drevision=${PROJECT_VERSION} \
+    -Dmaven.test.redirectTestOutputToFile=false \
+    -Dsonar.host.url=$SONAR_HOST_URL \
+    -Dsonar.login=$SONAR_TOKEN \
+    -Dsonar.branch.name=$GITHUB_BRANCH \
+    -Dsonar.analysis.buildNumber=$PULL_REQUEST \
+    -Dsonar.analysis.pipeline=$PIPELINE_ID \
+    -Dsonar.analysis.sha1=$GIT_SHA1  \
+    -Dsonar.analysis.repository=$GITHUB_REPO \
+    -B -e -V $*    
+        
+else
+  echo '======= Build, no analysis, no deploy'
+
+  # No need for Maven phase "install" as the generated JAR files do not need to be installed
+  # in Maven local repository. Phase "verify" is enough.
+
+  mvn verify \
+      -Drevision=${PROJECT_VERSION} \
+      -Dmaven.test.redirectTestOutputToFile=false \
+      -B -e -V $*
+fi

--- a/.cirrus/set_maven_build_version
+++ b/.cirrus/set_maven_build_version
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+BUILD_ID=$1
+CURRENT_VERSION=`maven_expression "project.version"`
+RELEASE_VERSION=${CURRENT_VERSION%"-SNAPSHOT"}
+
+# In case of 2 digits, we need to add the 3rd digit (0 obviously)
+# Mandatory in order to compare versions (patch VS non patch)
+IFS=$'.'
+DIGIT_COUNT=`echo ${RELEASE_VERSION} | wc -w`
+unset IFS
+if [[ ${DIGIT_COUNT} -lt 3 ]]; then
+    RELEASE_VERSION="$RELEASE_VERSION.0"
+fi
+NEW_VERSION="$RELEASE_VERSION.$BUILD_ID"
+
+export PROJECT_VERSION=${NEW_VERSION}

--- a/its/plugin/plugins/php-custom-rules-plugin/pom.xml
+++ b/its/plugin/plugins/php-custom-rules-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.php</groupId>
     <artifactId>it-php-plugin-plugins</artifactId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>php-custom-rules-plugin</artifactId>

--- a/its/plugin/plugins/pom.xml
+++ b/its/plugin/plugins/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.php</groupId>
     <artifactId>it-php-plugin</artifactId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>it-php-plugin-plugins</artifactId>

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.php</groupId>
     <artifactId>php-its</artifactId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>it-php-plugin</artifactId>

--- a/its/plugin/tests/pom.xml
+++ b/its/plugin/tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.php</groupId>
     <artifactId>it-php-plugin</artifactId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>it-php-plugin-tests</artifactId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.php</groupId>
     <artifactId>php</artifactId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>php-its</artifactId>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.php</groupId>
     <artifactId>php-its</artifactId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>it-php-ruling</artifactId>

--- a/php-checks/pom.xml
+++ b/php-checks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>php</artifactId>
     <groupId>org.sonarsource.php</groupId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>php-checks</artifactId>

--- a/php-frontend/pom.xml
+++ b/php-frontend/pom.xml
@@ -4,7 +4,7 @@
 
   <parent>
     <groupId>org.sonarsource.php</groupId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
     <artifactId>php</artifactId>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.php</groupId>
   <artifactId>php</artifactId>
-  <version>3.3-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <name>SonarPHP</name>
@@ -72,6 +72,8 @@
   </ciManagement>
 
   <properties>
+    <revision>3.3-SNAPSHOT</revision>
+    <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
     <gitRepositoryName>sonar-php</gitRepositoryName>
     <license.title>SonarQube PHP Plugin</license.title>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
@@ -253,6 +255,33 @@
   </dependencyManagement>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/sonar-php-plugin/pom.xml
+++ b/sonar-php-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.php</groupId>
     <artifactId>php</artifactId>
-    <version>3.3-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>sonar-php-plugin</artifactId>
@@ -127,6 +127,7 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
Use `${revision}` property to configure the version of the maven project. This way artifact version can be set via command-line and doesn't require modification of the files before the build. This will avoid the SQ warning about "Missing blame information... "

Also bumping the version it's easier because only the main pom of the project needs to be updated.

See https://maven.apache.org/maven-ci-friendly.html