### PR TITLE
SONARPHP-884 Identify if class declaration is in namespace

### DIFF
--- a/its/ruling/src/test/resources/expected/php-S1603.json
+++ b/its/ruling/src/test/resources/expected/php-S1603.json
@@ -1,8 +1,0 @@
-{
-'project:PhpSpreadsheet/src/PhpSpreadsheet/Reader/Xls/RC4.php':[
-44,
-],
-'project:Symfony/Component/HttpKernel/Tests/HttpKernelTest.php':[
-382,
-],
-}

--- a/php-checks/src/main/java/org/sonar/php/checks/ConstructorDeclarationCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/ConstructorDeclarationCheck.java
@@ -80,7 +80,7 @@ public class ConstructorDeclarationCheck extends PHPSubscriptionCheck {
    * If there are several namespaces, classes can belong to different namespaces,
    * but each class must then belong to one namespace
    */
-  private boolean isClassInNamespaceContext(ClassDeclarationTree classDec) {
+  private static boolean isClassInNamespaceContext(ClassDeclarationTree classDec) {
     Tree parent = classDec.getParent();
     if (parent != null && parent.is(Kind.SCRIPT)) {
       ScriptTree scriptTree = (ScriptTree) parent;

--- a/php-checks/src/main/java/org/sonar/php/checks/ConstructorDeclarationCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/ConstructorDeclarationCheck.java
@@ -22,7 +22,8 @@ package org.sonar.php.checks;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.sonar.check.Rule;
-import org.sonar.plugins.php.api.tree.ScriptTree;
+import org.sonar.plugins.php.api.symbols.QualifiedName;
+import org.sonar.plugins.php.api.symbols.Symbol;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
@@ -75,23 +76,9 @@ public class ConstructorDeclarationCheck extends PHPSubscriptionCheck {
     }
   }
 
-  /**
-   * If there is a namespace that is declared at the file script level, then all classes belong to this namespace.
-   * If there are several namespaces, classes can belong to different namespaces,
-   * but each class must then belong to one namespace
-   */
-  private static boolean isClassInNamespaceContext(ClassDeclarationTree classDec) {
-    Tree parent = classDec.getParent();
-    if (parent != null && parent.is(Kind.SCRIPT)) {
-      ScriptTree scriptTree = (ScriptTree) parent;
-
-      for (Tree statement : scriptTree.statements()) {
-        if (statement.is(Kind.NAMESPACE_STATEMENT)) {
-          return true;
-        }
-      }
-    }
-
-    return false;
+  private boolean isClassInNamespaceContext(ClassDeclarationTree classDec) {
+    Symbol symbol = context().symbolTable().getSymbol(classDec.name());
+    QualifiedName qualifiedName = symbol.qualifiedName();
+    return qualifiedName != null && !qualifiedName.toString().equals(symbol.name());
   }
 }

--- a/php-checks/src/test/java/org/sonar/php/checks/ConstructorDeclarationCheckTest.java
+++ b/php-checks/src/test/java/org/sonar/php/checks/ConstructorDeclarationCheckTest.java
@@ -27,6 +27,7 @@ public class ConstructorDeclarationCheckTest {
   @Test
   public void test() throws Exception {
     CheckVerifier.verify(new ConstructorDeclarationCheck(), "ConstructorDeclarationCheck.php");
+    CheckVerifier.verifyNoIssue(new ConstructorDeclarationCheck(), "ConstructorDeclarationInNamespaceCheck.php");
   }
 
 }

--- a/php-checks/src/test/resources/checks/ConstructorDeclarationInNamespaceCheck.php
+++ b/php-checks/src/test/resources/checks/ConstructorDeclarationInNamespaceCheck.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MyNamespace;
+
+class C {
+
+  public function C() {   // OK
+  }
+}
+


### PR DESCRIPTION
If a class is in a namespace, a method is no longer used as a constructor if it has the same name as the class. If there is a namespace that is declared at the file script level, then all classes belong to this namespace. If there are several namespaces, classes can belong to different namespaces,
but each class must then belong to one namespace.