### PR TITLE
SONARPHP-764 fix false positives

### DIFF
--- a/php-checks/src/test/resources/checks/OverwrittenArrayElementCheck.php
+++ b/php-checks/src/test/resources/checks/OverwrittenArrayElementCheck.php
@@ -53,6 +53,14 @@ $bla = function($j) {
 $h[1][2] = "foo";
 $h[1][2] = "bar"; // Compliant - FN only 1-dimensional array writes are currently supported
 
+foreach($results as $result) {
+  $array[1] = "foo";
+  if ($someCondition) {
+    continue;
+  }
+  $array[1] = $x->getValue(); // compliant
+}
+
 // Coverage
 $z = "foo";
 foo()[1] = "foo";

--- a/php-checks/src/test/resources/checks/OverwrittenArrayElementCheck.php
+++ b/php-checks/src/test/resources/checks/OverwrittenArrayElementCheck.php
@@ -61,6 +61,10 @@ foreach($results as $result) {
   $array[1] = $x->getValue(); // compliant
 }
 
+$GLOBALS["user"] = $adminUser;
+handleRequest();
+$GLOBALS["user"] = $defaultUser; // Compliant
+
 // Coverage
 $z = "foo";
 foo()[1] = "foo";


### PR DESCRIPTION
Fix false positives related to global array writes and having a flow-breaking statement (e.g., "continue;") between two separate writes. 