### PR TITLE
SONARPHP-1075: S4784 should be deprecated because it's too noisy

### DIFF
--- a/php-checks/src/main/resources/org/sonar/l10n/php/rules/php/S4784.html
+++ b/php-checks/src/main/resources/org/sonar/l10n/php/rules/php/S4784.html
@@ -76,5 +76,5 @@ $result = eregi($pattern, $input);  // No issue will be raised even if it is Sen
   <li> OWASP Regular expression Denial of Service - ReDoS </li>
 </ul>
 <h2>Deprecated</h2>
-<p>This rule is deprecated; use {rule:php:S2631} instead.</p>
+<p>This rule is deprecated; use {rule:phpsecurity:S2631} instead.</p>
 

--- a/php-checks/src/main/resources/org/sonar/l10n/php/rules/php/S4784.html
+++ b/php-checks/src/main/resources/org/sonar/l10n/php/rules/php/S4784.html
@@ -75,4 +75,6 @@ $result = eregi($pattern, $input);  // No issue will be raised even if it is Sen
   </li>
   <li> OWASP Regular expression Denial of Service - ReDoS </li>
 </ul>
+<h2>Deprecated</h2>
+<p>This rule is deprecated; use {rule:php:S2631} instead.</p>
 

--- a/php-checks/src/main/resources/org/sonar/l10n/php/rules/php/S4784.json
+++ b/php-checks/src/main/resources/org/sonar/l10n/php/rules/php/S4784.json
@@ -1,7 +1,7 @@
 {
   "title": "Using regular expressions is security-sensitive",
   "type": "SECURITY_HOTSPOT",
-  "status": "ready",
+  "status": "deprecated",
   "tags": [
     
   ],

--- a/php-checks/src/main/resources/org/sonar/l10n/php/rules/php/S4787.html
+++ b/php-checks/src/main/resources/org/sonar/l10n/php/rules/php/S4787.html
@@ -262,5 +262,5 @@ function myZendEncrypt($key, $data, $prime, $options, $generator, $lib)
   <li> <a href="https://www.sans.org/top25-software-errors/#cat3">SANS Top 25</a> - Porous Defenses </li>
 </ul>
 <h2>Deprecated</h2>
-<p>This rule is deprecated, and will eventually be removed.</p>
+<p>This rule is deprecated; use {rule:php:S4426}, {rule:php:S5542}, {rule:php:S5547} instead.</p>
 

--- a/sonarpedia.json
+++ b/sonarpedia.json
@@ -3,7 +3,7 @@
   "languages": [
     "PHP"
   ],
-  "latest-update": "2020-10-05T08:01:28.128899Z",
+  "latest-update": "2020-10-19T09:51:45.723468Z",
   "options": {
     "no-language-in-filenames": true,
     "preserve-filenames": true


### PR DESCRIPTION
Metadata of all rules was updated (no need to redo if we are going to release these days).