### PR TITLE
SONARPHP-1117 FP on S2115 where a variable is reassigned using "list"

### DIFF
--- a/php-checks/src/test/resources/checks/EmptyDatabasePasswordCheck.php
+++ b/php-checks/src/test/resources/checks/EmptyDatabasePasswordCheck.php
@@ -121,4 +121,10 @@ function withList() {
   $pwd = '';
   list($user, $pwd) = getConnectionData();
   $conn = new mysqli($servername, $user, $pwd);
+
+  list(1 => $emptyUser_2, 0 => $emptyPwd_2) = ["", ""];
+  $conn = new mysqli($servername, $emptyUser_2, $emptyPwd_2); // FN - list() with keys is not handled
+
+  list($emptyUser_3, $emptyPwd_3) = [1 => "", 0 => ""];
+  $conn = new mysqli($servername, $emptyUser_3, $emptyPwd_3); // FN - list() with keys is not handled
 }

--- a/php-checks/src/test/resources/checks/EmptyDatabasePasswordCheck.php
+++ b/php-checks/src/test/resources/checks/EmptyDatabasePasswordCheck.php
@@ -112,3 +112,13 @@ function postgresql() {
     $str3 = "host=localhost port=5432 dbname=test user=john password=secret";
     $conn = pg_connect($str3);
 }
+
+function withList() {
+  list($emptyUser, $emptyPwd) = ["", ""];
+  $conn = new mysqli($servername, $emptyUser, $emptyPwd); // Noncompliant
+
+  $user = '';
+  $pwd = '';
+  list($user, $pwd) = getConnectionData();
+  $conn = new mysqli($servername, $user, $pwd);
+}

--- a/php-frontend/src/main/java/org/sonar/php/tree/visitors/AssignmentExpressionVisitor.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/visitors/AssignmentExpressionVisitor.java
@@ -32,6 +32,7 @@ import org.sonar.plugins.php.api.symbols.SymbolTable;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.expression.ArrayAssignmentPatternElementTree;
 import org.sonar.plugins.php.api.tree.expression.ArrayInitializerTree;
+import org.sonar.plugins.php.api.tree.expression.ArrayPairTree;
 import org.sonar.plugins.php.api.tree.expression.AssignmentExpressionTree;
 import org.sonar.plugins.php.api.tree.expression.ExpressionTree;
 import org.sonar.plugins.php.api.tree.expression.ListExpressionTree;
@@ -64,9 +65,15 @@ public class AssignmentExpressionVisitor extends PHPVisitorCheck {
   private void handleListAssignment(ListExpressionTree lhs, ExpressionTree rhs) {
     List<ExpressionTree> values = new ArrayList<>();
     if (rhs.is(Tree.Kind.ARRAY_INITIALIZER_BRACKET, Tree.Kind.ARRAY_INITIALIZER_FUNCTION)) {
-      ((ArrayInitializerTree)rhs).arrayPairs().stream()
-        .filter(p -> p.key() == null)
-        .forEach(p -> values.add(p.value()));
+      for (ArrayPairTree arrayPair: ((ArrayInitializerTree)rhs).arrayPairs()) {
+        if (arrayPair.key() == null) {
+          values.add(arrayPair.value());
+        } else {
+          // keys are not supported yet
+          values.clear();
+          break;
+        }
+      }
     }
 
     int index = 0;

--- a/php-frontend/src/main/java/org/sonar/php/tree/visitors/AssignmentExpressionVisitor.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/visitors/AssignmentExpressionVisitor.java
@@ -79,13 +79,12 @@ public class AssignmentExpressionVisitor extends PHPVisitorCheck {
     int index = 0;
     final int numValues = values.size();
     for(Optional<ArrayAssignmentPatternElementTree> element : lhs.elements()) {
-      if (!element.isPresent()) {
-        index++;
-        continue;
-      }
-
-      if (index >= numValues || element.get().key() != null) {
-        assignToUnknown(element.get().variable());
+      if (!element.isPresent() || index >= numValues || element.get().key() != null) {
+        if (!element.isPresent()) {
+          index++;
+        } else {
+          assignToUnknown(element.get().variable());
+        }
         continue;
       }
 

--- a/php-frontend/src/test/java/org/sonar/php/tree/visitors/AssignmentExpressionVisitorTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/visitors/AssignmentExpressionVisitorTest.java
@@ -62,6 +62,40 @@ public class AssignmentExpressionVisitorTest {
     assertThat(uniqueAssignedValue).isNotPresent();
   }
 
+  @Test
+  public void getAssignmentValue_list() {
+    Optional<ExpressionTree> uniqueAssignedValue = UniqueAssignedValue.of("$a").from("<?php list($a, $b) = [1, 2];");
+
+    assertThat(uniqueAssignedValue).isPresent();
+    ExpressionTree value = uniqueAssignedValue.get();
+    assertThat(value).isInstanceOf(LiteralTree.class);
+    assertThat(((LiteralTree) value).value()).isEqualTo("1");
+  }
+
+  @Test
+  public void getAssignmentValue_list_unknown_values() {
+    Optional<ExpressionTree> uniqueAssignedValue = UniqueAssignedValue.of("$a").from("<?php $a = 1; list($a, $b) = getValues();");
+
+    assertThat(uniqueAssignedValue).isNotPresent();
+  }
+
+  @Test
+  public void getAssignmentValue_list_skipped_element() {
+    Optional<ExpressionTree> uniqueAssignedValue = UniqueAssignedValue.of("$b").from("<?php list($a, , $b) = [1, 2, 3];");
+
+    assertThat(uniqueAssignedValue).isPresent();
+    ExpressionTree value = uniqueAssignedValue.get();
+    assertThat(value).isInstanceOf(LiteralTree.class);
+    assertThat(((LiteralTree) value).value()).isEqualTo("3");
+  }
+
+  @Test
+  public void getAssignmentValue_list_keys_not_supported_yet() {
+    Optional<ExpressionTree> uniqueAssignedValue = UniqueAssignedValue.of("$a").from("<?php list($a, $b, 99 => $c) = [1 => 'b', 0 => 'a', 99 => 'c'];");
+
+    assertThat(uniqueAssignedValue).isNotPresent();
+  }
+
   private static class UniqueAssignedValue extends PHPTreeModelTest {
     private String name;
 

--- a/php-frontend/src/test/java/org/sonar/php/tree/visitors/AssignmentExpressionVisitorTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/visitors/AssignmentExpressionVisitorTest.java
@@ -90,8 +90,15 @@ public class AssignmentExpressionVisitorTest {
   }
 
   @Test
-  public void getAssignmentValue_list_keys_not_supported_yet() {
-    Optional<ExpressionTree> uniqueAssignedValue = UniqueAssignedValue.of("$a").from("<?php list($a, $b, 99 => $c) = [1 => 'b', 0 => 'a', 99 => 'c'];");
+  public void getAssignmentValue_list_var_keys_not_supported_yet() {
+    Optional<ExpressionTree> uniqueAssignedValue = UniqueAssignedValue.of("$a").from("<?php list(getAKey() => $a) = ['a'];");
+
+    assertThat(uniqueAssignedValue).isNotPresent();
+  }
+
+  @Test
+  public void getAssignmentValue_list_value_keys_not_supported_yet() {
+    Optional<ExpressionTree> uniqueAssignedValue = UniqueAssignedValue.of("$a").from("<?php list($a, $b) = [getAKey() => 'a', getBKey() => 'b'];");
 
     assertThat(uniqueAssignedValue).isNotPresent();
   }


### PR DESCRIPTION
The PR adds basic handling of the `list(....) = ....` construct in `AssignmentExpressionVisitor` to fix the false positive cause, but also assign the correct value in case of something simple such as `list($a, $b) = ['a value', 'b value']`. 

More complex usages of `list()` such as when it is nested in another `list()`, or the values are assigned based on keys, are not handled in this PR. 