### PR TITLE
SONARPHP-1171 Fix crash in EmptyMethodCheck with Arabic locale

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/EmptyMethodCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/EmptyMethodCheck.java
@@ -41,9 +41,7 @@ public class EmptyMethodCheck extends PHPVisitorCheck {
   private static final String MESSAGE = "Add a nested comment explaining why this %s is empty, throw an Exception or complete the implementation.";
 
   private static final int MIN_WORD_CHARS = 3;
-  private static final String VALUABLE_COMMENT_FORMAT = "\\w{%d}";
-
-  private static final Pattern VALUABLE_COMMENT_PATTERN = Pattern.compile(String.format(VALUABLE_COMMENT_FORMAT, MIN_WORD_CHARS));
+  private static final Pattern VALUABLE_COMMENT_PATTERN = Pattern.compile("\\w{"+ MIN_WORD_CHARS +"}");
 
 
   @Override


### PR DESCRIPTION
I'm not sure whether something should be done about tests.
Adding a test with an Arabic locale for this specific class would be weird.
Maybe we could add an integration test running all rules (ruling?).
We may consider that if we hit a similar bug in the future.