### PR TITLE
SONARPHP-1257 Parser should support basic enums

### DIFF
--- a/php-frontend/src/main/java/org/sonar/php/api/PHPKeyword.java
+++ b/php-frontend/src/main/java/org/sonar/php/api/PHPKeyword.java
@@ -50,6 +50,7 @@ public enum PHPKeyword implements GrammarRuleKey {
   ENDIF("endif"),
   ENDSWITCH("endswitch"),
   ENDWHILE("endwhile"),
+  ENUM("enum"),
   EVAL("eval"),
   EXIT("exit"),
   EXTENDS("extends"),

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
@@ -577,6 +577,7 @@ public class PHPGrammar {
         TRAIT_DECLARATION(),
         FUNCTION_DECLARATION(),
         INTERFACE_DECLARATION(),
+        ENUM_DECLARATION(),
         NAMESPACE_STATEMENT(),
         GROUP_USE_STATEMENT(),
         USE_STATEMENT(),

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
@@ -40,6 +40,7 @@ import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ConstantDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.DeclaredTypeTree;
+import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.FunctionDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -123,6 +124,7 @@ import static org.sonar.php.api.PHPKeyword.CALLABLE;
 import static org.sonar.php.api.PHPKeyword.CLASS;
 import static org.sonar.php.api.PHPKeyword.DIE;
 import static org.sonar.php.api.PHPKeyword.ECHO;
+import static org.sonar.php.api.PHPKeyword.ENUM;
 import static org.sonar.php.api.PHPKeyword.EXIT;
 import static org.sonar.php.api.PHPKeyword.EXTENDS;
 import static org.sonar.php.api.PHPKeyword.FINAL;
@@ -304,6 +306,17 @@ public class PHPGrammar {
         b.token(LCURLYBRACE),
         b.zeroOrMore(CLASS_MEMBER()),
         b.token(RCURLYBRACE)));
+  }
+
+  public EnumDeclarationTree ENUM_DECLARATION() {
+    return b.<EnumDeclarationTree>nonterminal(PHPLexicalGrammar.ENUM_DECLARATION).is(
+      f.enumDeclaration(
+        b.token(ENUM),
+        NAME_IDENTIFIER(),
+        b.token(LCURLYBRACE),
+        b.token(RCURLYBRACE)
+      )
+    );
   }
 
   public ClassMemberTree CLASS_MEMBER() {

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
@@ -92,6 +92,7 @@ import org.sonar.plugins.php.api.tree.statement.DoWhileStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ElseClauseTree;
 import org.sonar.plugins.php.api.tree.statement.ElseifClauseTree;
 import org.sonar.plugins.php.api.tree.statement.EmptyStatementTree;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionListStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ForEachStatementTree;
@@ -121,6 +122,7 @@ import org.sonar.plugins.php.api.tree.statement.WhileStatementTree;
 import static org.sonar.php.api.PHPKeyword.ABSTRACT;
 import static org.sonar.php.api.PHPKeyword.ARRAY;
 import static org.sonar.php.api.PHPKeyword.CALLABLE;
+import static org.sonar.php.api.PHPKeyword.CASE;
 import static org.sonar.php.api.PHPKeyword.CLASS;
 import static org.sonar.php.api.PHPKeyword.DIE;
 import static org.sonar.php.api.PHPKeyword.ECHO;
@@ -314,7 +316,18 @@ public class PHPGrammar {
         b.token(ENUM),
         NAME_IDENTIFIER(),
         b.token(LCURLYBRACE),
+        b.zeroOrMore(ENUM_CASE()),
         b.token(RCURLYBRACE)
+      )
+    );
+  }
+
+  public EnumCaseTree ENUM_CASE() {
+    return b.<EnumCaseTree>nonterminal(PHPLexicalGrammar.ENUM_CASE).is(
+      f.enumCase(
+        b.token(CASE),
+        NAME_IDENTIFIER(),
+        EOS()
       )
     );
   }

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPLexicalGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPLexicalGrammar.java
@@ -171,6 +171,8 @@ public enum PHPLexicalGrammar implements GrammarRuleKey {
   UNSET_VARIABLE_STATEMENT,
   UNSET_VARIABLES,
 
+  ENUM_CASE,
+
   /**
    * Expression
    */

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPLexicalGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPLexicalGrammar.java
@@ -39,6 +39,7 @@ public enum PHPLexicalGrammar implements GrammarRuleKey {
   CLASS_DECLARATION,
   INTERFACE_DECLARATION,
   TRAIT_DECLARATION,
+  ENUM_DECLARATION,
 
   CLASS_MEMBER,
 

--- a/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
@@ -112,6 +112,7 @@ import org.sonar.php.tree.impl.statement.EchoTagStatementTreeImpl;
 import org.sonar.php.tree.impl.statement.ElseClauseTreeImpl;
 import org.sonar.php.tree.impl.statement.ElseifClauseTreeImpl;
 import org.sonar.php.tree.impl.statement.EmptyStatementImpl;
+import org.sonar.php.tree.impl.statement.EnumCaseTreeImpl;
 import org.sonar.php.tree.impl.statement.ExpressionListStatementTreeImpl;
 import org.sonar.php.tree.impl.statement.ExpressionStatementTreeImpl;
 import org.sonar.php.tree.impl.statement.ForEachStatementTreeImpl;
@@ -207,6 +208,7 @@ import org.sonar.plugins.php.api.tree.statement.EchoTagStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ElseClauseTree;
 import org.sonar.plugins.php.api.tree.statement.ElseifClauseTree;
 import org.sonar.plugins.php.api.tree.statement.EmptyStatementTree;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionListStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ForEachStatementTree;
@@ -653,8 +655,13 @@ public class TreeFactory {
     );
   }
 
-  public EnumDeclarationTree enumDeclaration(InternalSyntaxToken enumToken, NameIdentifierTree name, InternalSyntaxToken openCurlyBraceToken, InternalSyntaxToken closeCurlyBraceToken) {
-    return new EnumDeclarationTreeImpl(enumToken, name, openCurlyBraceToken, closeCurlyBraceToken);
+  public EnumDeclarationTree enumDeclaration(SyntaxToken enumToken, NameIdentifierTree name, SyntaxToken openCurlyBraceToken,
+    Optional<List<EnumCaseTree>> cases, SyntaxToken closeCurlyBraceToken) {
+    return new EnumDeclarationTreeImpl(enumToken, name, openCurlyBraceToken, cases.or(Collections.emptyList()), closeCurlyBraceToken);
+  }
+
+  public EnumCaseTree enumCase(SyntaxToken caseToken, NameIdentifierTree name, SyntaxToken eosToken) {
+    return new EnumCaseTreeImpl(caseToken, name, eosToken);
   }
 
   /**

--- a/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
@@ -44,6 +44,7 @@ import org.sonar.php.tree.impl.declaration.ClassDeclarationTreeImpl;
 import org.sonar.php.tree.impl.declaration.ClassNamespaceNameTreeImpl;
 import org.sonar.php.tree.impl.declaration.ClassPropertyDeclarationTreeImpl;
 import org.sonar.php.tree.impl.declaration.ConstantDeclarationTreeImpl;
+import org.sonar.php.tree.impl.declaration.EnumDeclarationTreeImpl;
 import org.sonar.php.tree.impl.declaration.FunctionDeclarationTreeImpl;
 import org.sonar.php.tree.impl.declaration.MethodDeclarationTreeImpl;
 import org.sonar.php.tree.impl.declaration.NamespaceNameTreeImpl;
@@ -148,6 +149,7 @@ import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ConstantDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.DeclaredTypeTree;
+import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.FunctionDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -649,6 +651,10 @@ public class TreeFactory {
       implementsToken(implementsClause), superInterfaces(implementsClause),
       openCurlyBrace, optionalList(members), closeCurlyBrace
     );
+  }
+
+  public EnumDeclarationTree enumDeclaration(InternalSyntaxToken enumToken, NameIdentifierTree name, InternalSyntaxToken openCurlyBraceToken, InternalSyntaxToken closeCurlyBraceToken) {
+    return new EnumDeclarationTreeImpl(enumToken, name, openCurlyBraceToken, closeCurlyBraceToken);
   }
 
   /**
@@ -1931,6 +1937,8 @@ public class TreeFactory {
   public AttributeGroupTree attributeGroup(SyntaxToken startToken, SeparatedList<AttributeTree> attributes, SyntaxToken endToken) {
     return new AttributeGroupTreeImpl(startToken, attributes, endToken);
   }
+
+
 
   /**
    * [ END ] Expression

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.php.tree.impl.declaration;
 
 import java.util.Iterator;

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
@@ -1,0 +1,61 @@
+package org.sonar.php.tree.impl.declaration;
+
+import java.util.Iterator;
+import org.sonar.php.tree.impl.PHPTree;
+import org.sonar.php.utils.collections.IteratorUtils;
+import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
+import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
+import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+import org.sonar.plugins.php.api.visitors.VisitorCheck;
+
+public class EnumDeclarationTreeImpl extends PHPTree implements EnumDeclarationTree {
+
+  private final SyntaxToken enumToken;
+  private final NameIdentifierTree name;
+  private final SyntaxToken openCurlyBraceToken;
+  private final SyntaxToken closeCurlyBraceToken;
+
+  public EnumDeclarationTreeImpl(SyntaxToken enumToken, NameIdentifierTree name, SyntaxToken openCurlyBraceToken,
+    SyntaxToken closeCurlyBraceToken) {
+    this.enumToken = enumToken;
+    this.name = name;
+    this.openCurlyBraceToken = openCurlyBraceToken;
+    this.closeCurlyBraceToken = closeCurlyBraceToken;
+  }
+
+  @Override
+  public SyntaxToken enumToken() {
+    return enumToken;
+  }
+
+  @Override
+  public NameIdentifierTree name() {
+    return name;
+  }
+
+  @Override
+  public SyntaxToken openCurlyBraceToken() {
+    return openCurlyBraceToken;
+  }
+
+  @Override
+  public SyntaxToken closeCurlyBraceToken() {
+    return closeCurlyBraceToken;
+  }
+
+  @Override
+  public Iterator<Tree> childrenIterator() {
+    return IteratorUtils.iteratorOf(enumToken, name, openCurlyBraceToken, closeCurlyBraceToken);
+  }
+
+  @Override
+  public void accept(VisitorCheck visitor) {
+
+  }
+
+  @Override
+  public Kind getKind() {
+    return Kind.ENUM_DECLARATION;
+  }
+}

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
@@ -1,12 +1,14 @@
 package org.sonar.php.tree.impl.declaration;
 
 import java.util.Iterator;
+import java.util.List;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.php.utils.collections.IteratorUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
 import org.sonar.plugins.php.api.visitors.VisitorCheck;
 
 public class EnumDeclarationTreeImpl extends PHPTree implements EnumDeclarationTree {
@@ -14,13 +16,15 @@ public class EnumDeclarationTreeImpl extends PHPTree implements EnumDeclarationT
   private final SyntaxToken enumToken;
   private final NameIdentifierTree name;
   private final SyntaxToken openCurlyBraceToken;
+  private final List<EnumCaseTree> cases;
   private final SyntaxToken closeCurlyBraceToken;
 
   public EnumDeclarationTreeImpl(SyntaxToken enumToken, NameIdentifierTree name, SyntaxToken openCurlyBraceToken,
-    SyntaxToken closeCurlyBraceToken) {
+    List<EnumCaseTree> cases, SyntaxToken closeCurlyBraceToken) {
     this.enumToken = enumToken;
     this.name = name;
     this.openCurlyBraceToken = openCurlyBraceToken;
+    this.cases = cases;
     this.closeCurlyBraceToken = closeCurlyBraceToken;
   }
 
@@ -40,13 +44,20 @@ public class EnumDeclarationTreeImpl extends PHPTree implements EnumDeclarationT
   }
 
   @Override
+  public List<EnumCaseTree> cases() {
+    return cases;
+  }
+
+  @Override
   public SyntaxToken closeCurlyBraceToken() {
     return closeCurlyBraceToken;
   }
 
   @Override
   public Iterator<Tree> childrenIterator() {
-    return IteratorUtils.iteratorOf(enumToken, name, openCurlyBraceToken, closeCurlyBraceToken);
+    return IteratorUtils.concat(IteratorUtils.iteratorOf(enumToken, name, openCurlyBraceToken),
+      cases.iterator(),
+      IteratorUtils.iteratorOf(closeCurlyBraceToken));
   }
 
   @Override

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
@@ -62,7 +62,7 @@ public class EnumDeclarationTreeImpl extends PHPTree implements EnumDeclarationT
 
   @Override
   public void accept(VisitorCheck visitor) {
-
+    visitor.visitEnumDeclaration(this);
   }
 
   @Override

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/EnumCaseTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/EnumCaseTreeImpl.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.php.tree.impl.statement;
 
 import java.util.Iterator;

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/EnumCaseTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/EnumCaseTreeImpl.java
@@ -43,6 +43,7 @@ public class EnumCaseTreeImpl extends PHPTree implements EnumCaseTree {
 
   @Override
   public void accept(VisitorCheck visitor) {
+    visitor.visitEnumCase(this);
   }
 
   @Override

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/EnumCaseTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/EnumCaseTreeImpl.java
@@ -1,0 +1,52 @@
+package org.sonar.php.tree.impl.statement;
+
+import java.util.Iterator;
+import org.sonar.php.tree.impl.PHPTree;
+import org.sonar.php.utils.collections.IteratorUtils;
+import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
+import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
+import org.sonar.plugins.php.api.visitors.VisitorCheck;
+
+public class EnumCaseTreeImpl extends PHPTree implements EnumCaseTree {
+
+  private final SyntaxToken caseToken;
+  private final NameIdentifierTree name;
+  private final SyntaxToken eosToken;
+
+  public EnumCaseTreeImpl(SyntaxToken caseToken, NameIdentifierTree name, SyntaxToken eosToken) {
+    this.caseToken = caseToken;
+    this.name = name;
+    this.eosToken = eosToken;
+  }
+
+  @Override
+  public SyntaxToken caseToken() {
+    return caseToken;
+  }
+
+  @Override
+  public NameIdentifierTree name() {
+    return name;
+  }
+
+  @Override
+  public SyntaxToken eosToken() {
+    return eosToken;
+  }
+
+  @Override
+  public Iterator<Tree> childrenIterator() {
+    return IteratorUtils.iteratorOf(caseToken, name, eosToken);
+  }
+
+  @Override
+  public void accept(VisitorCheck visitor) {
+  }
+
+  @Override
+  public Kind getKind() {
+    return Kind.ENUM_CASE;
+  }
+}

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/Tree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/Tree.java
@@ -28,6 +28,7 @@ import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ConstantDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.FunctionDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -159,6 +160,11 @@ public interface Tree {
     * {@link ClassDeclarationTree}
     */
     TRAIT_DECLARATION(ClassDeclarationTree.class),
+
+    /**
+     * {@link EnumDeclarationTree}
+     */
+    ENUM_DECLARATION(EnumDeclarationTree.class),
 
     /**
      * {@link MethodDeclarationTree}

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/Tree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/Tree.java
@@ -89,6 +89,7 @@ import org.sonar.plugins.php.api.tree.statement.EchoTagStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ElseClauseTree;
 import org.sonar.plugins.php.api.tree.statement.ElseifClauseTree;
 import org.sonar.plugins.php.api.tree.statement.EmptyStatementTree;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionListStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ForEachStatementTree;
@@ -165,6 +166,11 @@ public interface Tree {
      * {@link EnumDeclarationTree}
      */
     ENUM_DECLARATION(EnumDeclarationTree.class),
+
+    /**
+     * {@link EnumCaseTree}
+     */
+    ENUM_CASE(EnumCaseTree.class),
 
     /**
      * {@link MethodDeclarationTree}

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
@@ -1,12 +1,12 @@
 package org.sonar.plugins.php.api.tree.declaration;
 
 import java.util.List;
-import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
+import org.sonar.plugins.php.api.tree.statement.StatementTree;
 
-public interface EnumDeclarationTree extends Tree {
+public interface EnumDeclarationTree extends StatementTree {
 
   SyntaxToken enumToken();
 

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
@@ -1,0 +1,16 @@
+package org.sonar.plugins.php.api.tree.declaration;
+
+import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
+import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+
+public interface EnumDeclarationTree extends Tree {
+
+  SyntaxToken enumToken();
+
+  NameIdentifierTree name();
+
+  SyntaxToken openCurlyBraceToken();
+
+  SyntaxToken closeCurlyBraceToken();
+}

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.plugins.php.api.tree.declaration;
 
 import java.util.List;

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
@@ -1,8 +1,10 @@
 package org.sonar.plugins.php.api.tree.declaration;
 
+import java.util.List;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
 
 public interface EnumDeclarationTree extends Tree {
 
@@ -11,6 +13,8 @@ public interface EnumDeclarationTree extends Tree {
   NameIdentifierTree name();
 
   SyntaxToken openCurlyBraceToken();
+
+  List<EnumCaseTree> cases();
 
   SyntaxToken closeCurlyBraceToken();
 }

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/statement/EnumCaseTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/statement/EnumCaseTree.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.plugins.php.api.tree.statement;
 
 import org.sonar.plugins.php.api.tree.Tree;

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/statement/EnumCaseTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/statement/EnumCaseTree.java
@@ -1,0 +1,14 @@
+package org.sonar.plugins.php.api.tree.statement;
+
+import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
+import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+
+public interface EnumCaseTree extends Tree {
+
+  SyntaxToken caseToken();
+
+  NameIdentifierTree name();
+
+  SyntaxToken eosToken();
+}

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/visitors/PHPVisitorCheck.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/visitors/PHPVisitorCheck.java
@@ -36,6 +36,7 @@ import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ConstantDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.FunctionDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -97,6 +98,7 @@ import org.sonar.plugins.php.api.tree.statement.EchoTagStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ElseClauseTree;
 import org.sonar.plugins.php.api.tree.statement.ElseifClauseTree;
 import org.sonar.plugins.php.api.tree.statement.EmptyStatementTree;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionListStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ForEachStatementTree;
@@ -598,6 +600,16 @@ public abstract class PHPVisitorCheck implements VisitorCheck {
 
   @Override
   public void visitAttribute(AttributeTree tree) {
+    scan(tree);
+  }
+
+  @Override
+  public void visitEnumDeclaration(EnumDeclarationTree tree) {
+    scan(tree);
+  }
+
+  @Override
+  public void visitEnumCase(EnumCaseTree tree) {
     scan(tree);
   }
 

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/visitors/VisitorCheck.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/visitors/VisitorCheck.java
@@ -28,6 +28,7 @@ import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ConstantDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.FunctionDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -89,6 +90,7 @@ import org.sonar.plugins.php.api.tree.statement.EchoTagStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ElseClauseTree;
 import org.sonar.plugins.php.api.tree.statement.ElseifClauseTree;
 import org.sonar.plugins.php.api.tree.statement.EmptyStatementTree;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionListStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ExpressionStatementTree;
 import org.sonar.plugins.php.api.tree.statement.ForEachStatementTree;
@@ -156,6 +158,8 @@ public interface VisitorCheck extends PHPCheck {
   void visitBuiltInType(BuiltInTypeTree tree);
 
   void visitReturnTypeClause(ReturnTypeClauseTree tree);
+
+  void visitEnumDeclaration(EnumDeclarationTree tree);
 
   /**
    * [ END ] Declaration
@@ -231,6 +235,8 @@ public interface VisitorCheck extends PHPCheck {
   void visitNamespaceStatement(NamespaceStatementTree tree);
 
   void visitEchoTagStatement(EchoTagStatementTree tree);
+
+  void visitEnumCase(EnumCaseTree tree);
 
   /**
    * [ END ] Statement

--- a/php-frontend/src/test/java/org/sonar/php/parser/KeywordTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/KeywordTest.java
@@ -57,6 +57,7 @@ public class KeywordTest {
       .matches("endif")
       .matches("endswitch")
       .matches("endwhile")
+      .matches("enum")
       .matches("eval")
       .matches("exit")
       .matches("extends")
@@ -103,7 +104,7 @@ public class KeywordTest {
 
   @Test
   public void getKeywordValues() {
-    Assertions.assertThat(PHPKeyword.getKeywordValues()).hasSize(69);
+    Assertions.assertThat(PHPKeyword.getKeywordValues()).hasSize(70);
   }
 
 }

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
@@ -11,6 +11,10 @@ public class EnumDeclarationTest {
   public void test() {
     assertThat(PHPLexicalGrammar.ENUM_DECLARATION)
       .matches("enum A {}")
+      .matches("enum A { case A; }")
+      .matches("enum A {\n case A;\n case B; }")
+      .notMatches("enum A {")
+      .notMatches("enum A { case A}")
     ;
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
@@ -1,0 +1,16 @@
+package org.sonar.php.parser.declaration;
+
+import org.junit.Test;
+import org.sonar.php.parser.PHPLexicalGrammar;
+
+import static org.sonar.php.utils.Assertions.assertThat;
+
+public class EnumDeclarationTest {
+
+  @Test
+  public void test() {
+    assertThat(PHPLexicalGrammar.ENUM_DECLARATION)
+      .matches("enum A {}")
+    ;
+  }
+}

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.php.parser.declaration;
 
 import org.junit.Test;

--- a/php-frontend/src/test/java/org/sonar/php/parser/statement/EnumCaseTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/statement/EnumCaseTest.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.php.parser.statement;
 
 import org.junit.Test;

--- a/php-frontend/src/test/java/org/sonar/php/parser/statement/EnumCaseTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/statement/EnumCaseTest.java
@@ -1,0 +1,17 @@
+package org.sonar.php.parser.statement;
+
+import org.junit.Test;
+import org.sonar.php.parser.PHPLexicalGrammar;
+
+import static org.sonar.php.utils.Assertions.assertThat;
+
+public class EnumCaseTest {
+
+  @Test
+  public void test() {
+    assertThat(PHPLexicalGrammar.ENUM_CASE)
+      .matches("case A;")
+      .notMatches("case A")
+    ;
+  }
+}

--- a/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
@@ -1,0 +1,34 @@
+package org.sonar.php.tree.impl.declaration;
+
+import org.junit.Test;
+import org.sonar.php.PHPTreeModelTest;
+import org.sonar.php.parser.PHPLexicalGrammar;
+import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnumDeclarationTreeTest extends PHPTreeModelTest {
+
+  @Test
+  public void simple_enum_with_no_cases() {
+    EnumDeclarationTreeImpl tree = parse("enum A {}", PHPLexicalGrammar.ENUM_DECLARATION);
+
+    assertThat(tree.is(Tree.Kind.ENUM_DECLARATION)).isTrue();
+    assertThat(tree.childrenIterator()).hasSize(4);
+    assertThat(tree.name()).hasToString("A");
+    assertThat(tree.openCurlyBraceToken()).hasToString("{");
+    assertThat(tree.cases()).isEmpty();
+    assertThat(tree.closeCurlyBraceToken()).hasToString("}");
+  }
+
+  @Test
+  public void simple_enum_with_cases() {
+    EnumDeclarationTree tree = parse("enum A {case A;\ncase B;}", PHPLexicalGrammar.ENUM_DECLARATION);
+    assertThat(tree.is(Tree.Kind.ENUM_DECLARATION)).isTrue();
+    assertThat(tree.name()).hasToString("A");
+    assertThat(tree.cases()).hasSize(2);
+    assertThat(tree.cases().get(0).name()).hasToString("A");
+    assertThat(tree.cases().get(1).name()).hasToString("B");
+  }
+}

--- a/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.php.tree.impl.declaration;
 
 import org.junit.Test;

--- a/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
@@ -35,6 +35,7 @@ public class EnumDeclarationTreeTest extends PHPTreeModelTest {
 
     assertThat(tree.is(Tree.Kind.ENUM_DECLARATION)).isTrue();
     assertThat(tree.childrenIterator()).hasSize(4);
+    assertThat(tree.enumToken()).hasToString("enum");
     assertThat(tree.name()).hasToString("A");
     assertThat(tree.openCurlyBraceToken()).hasToString("{");
     assertThat(tree.cases()).isEmpty();

--- a/php-frontend/src/test/java/org/sonar/php/tree/impl/statement/EnumCaseTreeTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/impl/statement/EnumCaseTreeTest.java
@@ -1,0 +1,22 @@
+package org.sonar.php.tree.impl.statement;
+
+import org.junit.Test;
+import org.sonar.php.PHPTreeModelTest;
+import org.sonar.php.parser.PHPLexicalGrammar;
+import org.sonar.plugins.php.api.tree.Tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnumCaseTreeTest extends PHPTreeModelTest {
+
+  @Test
+  public void simple_case() {
+    EnumCaseTreeImpl tree = parse("case A;", PHPLexicalGrammar.ENUM_CASE);
+
+    assertThat(tree.is(Tree.Kind.ENUM_CASE)).isTrue();
+    assertThat(tree.childrenIterator()).hasSize(3);
+    assertThat(tree.caseToken()).hasToString("case");
+    assertThat(tree.name()).hasToString("A");
+    assertThat(tree.eosToken()).hasToString(";");
+  }
+}

--- a/php-frontend/src/test/java/org/sonar/php/tree/impl/statement/EnumCaseTreeTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/impl/statement/EnumCaseTreeTest.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.php.tree.impl.statement;
 
 import org.junit.Test;

--- a/php-frontend/src/test/java/org/sonar/php/tree/visitors/PHPVisitorCheckTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/visitors/PHPVisitorCheckTest.java
@@ -31,6 +31,7 @@ import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.AttributeGroupTree;
 import org.sonar.plugins.php.api.tree.declaration.AttributeTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
 import org.sonar.plugins.php.api.tree.declaration.UnionTypeTree;
 import org.sonar.plugins.php.api.tree.expression.BinaryExpressionTree;
@@ -39,6 +40,7 @@ import org.sonar.plugins.php.api.tree.expression.LiteralTree;
 import org.sonar.plugins.php.api.tree.expression.VariableIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxTrivia;
+import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
 import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
 import org.sonar.plugins.php.api.visitors.PhpFile;
 import org.sonar.plugins.php.api.visitors.PhpIssue;
@@ -64,11 +66,13 @@ public class PHPVisitorCheckTest {
     // PHPCheck#init() is called by PHPAnalyzer
     assertThat(testVisitor.initCounter).isEqualTo(0);
     assertThat(testVisitor.literalCounter).isEqualTo(6);
-    assertThat(testVisitor.tokenCounter).isEqualTo(67);
+    assertThat(testVisitor.tokenCounter).isEqualTo(77);
     assertThat(testVisitor.triviaCounter).isEqualTo(2);
     assertThat(testVisitor.unionTypesCounter).isEqualTo(1);
     assertThat(testVisitor.attributeGroupsCounter).isEqualTo(2);
     assertThat(testVisitor.attributesCounter).isEqualTo(3);
+    assertThat(testVisitor.enumsCounter).isEqualTo(1);
+    assertThat(testVisitor.enumCasesCounter).isEqualTo(2);
   }
 
   @Test
@@ -158,6 +162,8 @@ public class PHPVisitorCheckTest {
     int unionTypesCounter = 0;
     int attributeGroupsCounter = 0;
     int attributesCounter = 0;
+    int enumsCounter = 0;
+    int enumCasesCounter = 0;
 
     @Override
     public void visitClassDeclaration(ClassDeclarationTree tree) {
@@ -214,8 +220,8 @@ public class PHPVisitorCheckTest {
 
     @Override
     public void visitLiteral(LiteralTree tree) {
-      literalCounter++;
       super.visitLiteral(tree);
+      literalCounter++;
     }
 
     @Override
@@ -223,6 +229,17 @@ public class PHPVisitorCheckTest {
       triviaCounter++;
     }
 
+    @Override
+    public void visitEnumDeclaration(EnumDeclarationTree tree) {
+      super.visitEnumDeclaration(tree);
+      enumsCounter++;
+    }
+
+    @Override
+    public void visitEnumCase(EnumCaseTree tree) {
+      super.visitEnumCase(tree);
+      enumCasesCounter++;
+    }
   }
 
 }

--- a/php-frontend/src/test/resources/visitors/test.php
+++ b/php-frontend/src/test/resources/visitors/test.php
@@ -14,3 +14,8 @@ class A extends B {
     match ($a) {default=>1};
   }
 }
+
+enum A {
+  case A;
+  case B;
+}


### PR DESCRIPTION
Goal of this PR is parsing of a first really simple enum. 
`EnumDeclarationTree` is subject to change in the next Ticket (SONARPHP-1259) in which it might extend `ClassDeclarationTree`. I wanted to avoid doing that in this PR to keep it simple and incremental.