### PR TITLE
SONARPHP-1259 Parser should support enums class-like syntax

### DIFF
--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
@@ -315,6 +315,7 @@ public class PHPGrammar {
       f.enumDeclaration(
         b.token(ENUM),
         NAME_IDENTIFIER(),
+        b.optional(f.newTuple(b.token(IMPLEMENTS), INTERFACE_LIST())),
         b.token(LCURLYBRACE),
         b.zeroOrMore(ENUM_MEMBER()),
         b.token(RCURLYBRACE)));

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
@@ -316,10 +316,20 @@ public class PHPGrammar {
         b.token(ENUM),
         NAME_IDENTIFIER(),
         b.token(LCURLYBRACE),
-        b.zeroOrMore(ENUM_CASE()),
-        b.token(RCURLYBRACE)
-      )
-    );
+        b.zeroOrMore(ENUM_MEMBER()),
+        b.token(RCURLYBRACE)));
+  }
+
+  /**
+   *  In contrast to class declarations, enums cannot contain properties. They do allow enum cases as an addition.
+   */
+  public ClassMemberTree ENUM_MEMBER() {
+    return b.<ClassMemberTree>nonterminal(PHPLexicalGrammar.ENUM_MEMBER).is(
+      b.firstOf(
+        METHOD_DECLARATION(),
+        CLASS_CONSTANT_DECLARATION(),
+        USE_TRAIT_DECLARATION(),
+        ENUM_CASE()));
   }
 
   public EnumCaseTree ENUM_CASE() {
@@ -327,9 +337,7 @@ public class PHPGrammar {
       f.enumCase(
         b.token(CASE),
         NAME_IDENTIFIER(),
-        EOS()
-      )
-    );
+        EOS()));
   }
 
   public ClassMemberTree CLASS_MEMBER() {

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
@@ -313,6 +313,7 @@ public class PHPGrammar {
   public EnumDeclarationTree ENUM_DECLARATION() {
     return b.<EnumDeclarationTree>nonterminal(PHPLexicalGrammar.ENUM_DECLARATION).is(
       f.enumDeclaration(
+        b.zeroOrMore(ATTRIBUTE_GROUP()),
         b.token(ENUM),
         NAME_IDENTIFIER(),
         b.optional(f.newTuple(b.token(IMPLEMENTS), INTERFACE_LIST())),
@@ -336,6 +337,7 @@ public class PHPGrammar {
   public EnumCaseTree ENUM_CASE() {
     return b.<EnumCaseTree>nonterminal(PHPLexicalGrammar.ENUM_CASE).is(
       f.enumCase(
+        b.zeroOrMore(ATTRIBUTE_GROUP()),
         b.token(CASE),
         NAME_IDENTIFIER(),
         EOS()));

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPLexicalGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPLexicalGrammar.java
@@ -42,6 +42,7 @@ public enum PHPLexicalGrammar implements GrammarRuleKey {
   ENUM_DECLARATION,
 
   CLASS_MEMBER,
+  ENUM_MEMBER,
 
   METHOD_DECLARATION,
   CLASS_VARIABLE_DECLARATION,

--- a/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
@@ -656,8 +656,8 @@ public class TreeFactory {
   }
 
   public EnumDeclarationTree enumDeclaration(SyntaxToken enumToken, NameIdentifierTree name, SyntaxToken openCurlyBraceToken,
-    Optional<List<EnumCaseTree>> cases, SyntaxToken closeCurlyBraceToken) {
-    return new EnumDeclarationTreeImpl(enumToken, name, openCurlyBraceToken, cases.or(Collections.emptyList()), closeCurlyBraceToken);
+    Optional<List<ClassMemberTree>> members, SyntaxToken closeCurlyBraceToken) {
+    return new EnumDeclarationTreeImpl(enumToken, name, openCurlyBraceToken, members.or(Collections.emptyList()), closeCurlyBraceToken);
   }
 
   public EnumCaseTree enumCase(SyntaxToken caseToken, NameIdentifierTree name, SyntaxToken eosToken) {

--- a/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
@@ -655,9 +655,11 @@ public class TreeFactory {
     );
   }
 
-  public EnumDeclarationTree enumDeclaration(SyntaxToken enumToken, NameIdentifierTree name, SyntaxToken openCurlyBraceToken,
+  public EnumDeclarationTree enumDeclaration(SyntaxToken enumToken, NameIdentifierTree name,
+    Optional<Tuple<InternalSyntaxToken, SeparatedListImpl<NamespaceNameTree>>> implementsClause, SyntaxToken openCurlyBraceToken,
     Optional<List<ClassMemberTree>> members, SyntaxToken closeCurlyBraceToken) {
-    return new EnumDeclarationTreeImpl(enumToken, name, openCurlyBraceToken, members.or(Collections.emptyList()), closeCurlyBraceToken);
+    return new EnumDeclarationTreeImpl(enumToken, name, implementsToken(implementsClause), superInterfaces(implementsClause),
+      openCurlyBraceToken, members.or(Collections.emptyList()), closeCurlyBraceToken);
   }
 
   public EnumCaseTree enumCase(SyntaxToken caseToken, NameIdentifierTree name, SyntaxToken eosToken) {

--- a/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/TreeFactory.java
@@ -655,15 +655,16 @@ public class TreeFactory {
     );
   }
 
-  public EnumDeclarationTree enumDeclaration(SyntaxToken enumToken, NameIdentifierTree name,
+  public EnumDeclarationTree enumDeclaration(Optional<List<AttributeGroupTree>> attributes, SyntaxToken enumToken, NameIdentifierTree name,
     Optional<Tuple<InternalSyntaxToken, SeparatedListImpl<NamespaceNameTree>>> implementsClause, SyntaxToken openCurlyBraceToken,
     Optional<List<ClassMemberTree>> members, SyntaxToken closeCurlyBraceToken) {
-    return new EnumDeclarationTreeImpl(enumToken, name, implementsToken(implementsClause), superInterfaces(implementsClause),
-      openCurlyBraceToken, members.or(Collections.emptyList()), closeCurlyBraceToken);
+    return new EnumDeclarationTreeImpl(attributes.or(Collections.emptyList()), enumToken, name, implementsToken(implementsClause),
+      superInterfaces(implementsClause), openCurlyBraceToken, members.or(Collections.emptyList()), closeCurlyBraceToken);
   }
 
-  public EnumCaseTree enumCase(SyntaxToken caseToken, NameIdentifierTree name, SyntaxToken eosToken) {
-    return new EnumCaseTreeImpl(caseToken, name, eosToken);
+  public EnumCaseTree enumCase(Optional<List<AttributeGroupTree>> attributes, SyntaxToken caseToken,
+    NameIdentifierTree name, SyntaxToken eosToken) {
+    return new EnumCaseTreeImpl(attributes.or(Collections.emptyList()), caseToken, name, eosToken);
   }
 
   /**

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/ClassDeclarationTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/ClassDeclarationTreeImpl.java
@@ -55,7 +55,7 @@ public class ClassDeclarationTreeImpl extends PHPTree implements ClassDeclaratio
   private final SyntaxToken closeCurlyBraceToken;
   private ClassSymbol symbol;
 
-  private ClassDeclarationTreeImpl(
+  protected ClassDeclarationTreeImpl(
       Kind kind,
       List<AttributeGroupTree> attributeGroups,
       @Nullable SyntaxToken modifierToken, SyntaxToken classEntryTypeToken, NameIdentifierTree name,

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
@@ -19,47 +19,28 @@
  */
 package org.sonar.php.tree.impl.declaration;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import org.sonar.php.tree.impl.PHPTree;
+import java.util.stream.Collectors;
+import org.sonar.php.tree.impl.SeparatedListImpl;
 import org.sonar.php.utils.collections.IteratorUtils;
 import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
 import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
-import org.sonar.plugins.php.api.visitors.VisitorCheck;
 
-public class EnumDeclarationTreeImpl extends PHPTree implements EnumDeclarationTree {
+public class EnumDeclarationTreeImpl extends ClassDeclarationTreeImpl implements EnumDeclarationTree {
 
-  private final SyntaxToken enumToken;
-  private final NameIdentifierTree name;
-  private final SyntaxToken openCurlyBraceToken;
   private final List<EnumCaseTree> cases;
-  private final SyntaxToken closeCurlyBraceToken;
 
   public EnumDeclarationTreeImpl(SyntaxToken enumToken, NameIdentifierTree name, SyntaxToken openCurlyBraceToken,
-    List<EnumCaseTree> cases, SyntaxToken closeCurlyBraceToken) {
-    this.enumToken = enumToken;
-    this.name = name;
-    this.openCurlyBraceToken = openCurlyBraceToken;
-    this.cases = cases;
-    this.closeCurlyBraceToken = closeCurlyBraceToken;
-  }
-
-  @Override
-  public SyntaxToken enumToken() {
-    return enumToken;
-  }
-
-  @Override
-  public NameIdentifierTree name() {
-    return name;
-  }
-
-  @Override
-  public SyntaxToken openCurlyBraceToken() {
-    return openCurlyBraceToken;
+    List<ClassMemberTree> members, SyntaxToken closeCurlyBraceToken) {
+    super(Kind.ENUM_DECLARATION, Collections.emptyList(), null, enumToken, name, null, null,
+      null, new SeparatedListImpl<>(Collections.emptyList(), Collections.emptyList()), openCurlyBraceToken, members, closeCurlyBraceToken);
+    this.cases = members.stream().filter(m -> m.is(Kind.ENUM_CASE)).map(EnumCaseTree.class::cast).collect(Collectors.toList());
   }
 
   @Override
@@ -68,24 +49,9 @@ public class EnumDeclarationTreeImpl extends PHPTree implements EnumDeclarationT
   }
 
   @Override
-  public SyntaxToken closeCurlyBraceToken() {
-    return closeCurlyBraceToken;
-  }
-
-  @Override
   public Iterator<Tree> childrenIterator() {
-    return IteratorUtils.concat(IteratorUtils.iteratorOf(enumToken, name, openCurlyBraceToken),
-      cases.iterator(),
-      IteratorUtils.iteratorOf(closeCurlyBraceToken));
-  }
-
-  @Override
-  public void accept(VisitorCheck visitor) {
-    visitor.visitEnumDeclaration(this);
-  }
-
-  @Override
-  public Kind getKind() {
-    return Kind.ENUM_DECLARATION;
+    return IteratorUtils.concat(IteratorUtils.iteratorOf(classToken(), name(), openCurlyBraceToken()),
+      members().iterator(),
+      IteratorUtils.iteratorOf(closeCurlyBraceToken()));
   }
 }

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.php.tree.impl.declaration;
 
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,6 +27,7 @@ import org.sonar.php.tree.impl.SeparatedListImpl;
 import org.sonar.php.tree.impl.lexical.InternalSyntaxToken;
 import org.sonar.php.utils.collections.IteratorUtils;
 import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.declaration.AttributeGroupTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
 import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -39,10 +39,10 @@ public class EnumDeclarationTreeImpl extends ClassDeclarationTreeImpl implements
 
   private final List<EnumCaseTree> cases;
 
-  public EnumDeclarationTreeImpl(SyntaxToken enumToken, NameIdentifierTree name, @Nullable InternalSyntaxToken implementsToken,
-    SeparatedListImpl<NamespaceNameTree> superInterfaces,  SyntaxToken openCurlyBraceToken, List<ClassMemberTree> members,
-    SyntaxToken closeCurlyBraceToken) {
-    super(Kind.ENUM_DECLARATION, Collections.emptyList(), null, enumToken, name, null, null,
+  public EnumDeclarationTreeImpl(List<AttributeGroupTree> attributeGroups, SyntaxToken enumToken, NameIdentifierTree name,
+    @Nullable InternalSyntaxToken implementsToken, SeparatedListImpl<NamespaceNameTree> superInterfaces, SyntaxToken openCurlyBraceToken,
+    List<ClassMemberTree> members, SyntaxToken closeCurlyBraceToken) {
+    super(Kind.ENUM_DECLARATION, attributeGroups, null, enumToken, name, null, null,
       implementsToken, superInterfaces, openCurlyBraceToken, members, closeCurlyBraceToken);
     this.cases = members.stream().filter(m -> m.is(Kind.ENUM_CASE)).map(EnumCaseTree.class::cast).collect(Collectors.toList());
   }
@@ -54,7 +54,8 @@ public class EnumDeclarationTreeImpl extends ClassDeclarationTreeImpl implements
 
   @Override
   public Iterator<Tree> childrenIterator() {
-    return IteratorUtils.concat(IteratorUtils.iteratorOf(classToken(), name(), implementsToken()),
+    return IteratorUtils.concat(attributeGroups().iterator(),
+      IteratorUtils.iteratorOf(classToken(), name(), implementsToken()),
       superInterfaces().elementsAndSeparators(),
       IteratorUtils.iteratorOf(openCurlyBraceToken()),
       members().iterator(),

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeImpl.java
@@ -23,11 +23,14 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.sonar.php.tree.impl.SeparatedListImpl;
+import org.sonar.php.tree.impl.lexical.InternalSyntaxToken;
 import org.sonar.php.utils.collections.IteratorUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
 import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
+import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
@@ -36,10 +39,11 @@ public class EnumDeclarationTreeImpl extends ClassDeclarationTreeImpl implements
 
   private final List<EnumCaseTree> cases;
 
-  public EnumDeclarationTreeImpl(SyntaxToken enumToken, NameIdentifierTree name, SyntaxToken openCurlyBraceToken,
-    List<ClassMemberTree> members, SyntaxToken closeCurlyBraceToken) {
+  public EnumDeclarationTreeImpl(SyntaxToken enumToken, NameIdentifierTree name, @Nullable InternalSyntaxToken implementsToken,
+    SeparatedListImpl<NamespaceNameTree> superInterfaces,  SyntaxToken openCurlyBraceToken, List<ClassMemberTree> members,
+    SyntaxToken closeCurlyBraceToken) {
     super(Kind.ENUM_DECLARATION, Collections.emptyList(), null, enumToken, name, null, null,
-      null, new SeparatedListImpl<>(Collections.emptyList(), Collections.emptyList()), openCurlyBraceToken, members, closeCurlyBraceToken);
+      implementsToken, superInterfaces, openCurlyBraceToken, members, closeCurlyBraceToken);
     this.cases = members.stream().filter(m -> m.is(Kind.ENUM_CASE)).map(EnumCaseTree.class::cast).collect(Collectors.toList());
   }
 
@@ -50,7 +54,9 @@ public class EnumDeclarationTreeImpl extends ClassDeclarationTreeImpl implements
 
   @Override
   public Iterator<Tree> childrenIterator() {
-    return IteratorUtils.concat(IteratorUtils.iteratorOf(classToken(), name(), openCurlyBraceToken()),
+    return IteratorUtils.concat(IteratorUtils.iteratorOf(classToken(), name(), implementsToken()),
+      superInterfaces().elementsAndSeparators(),
+      IteratorUtils.iteratorOf(openCurlyBraceToken()),
       members().iterator(),
       IteratorUtils.iteratorOf(closeCurlyBraceToken()));
   }

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/EnumCaseTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/EnumCaseTreeImpl.java
@@ -20,9 +20,11 @@
 package org.sonar.php.tree.impl.statement;
 
 import java.util.Iterator;
+import java.util.List;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.php.utils.collections.IteratorUtils;
 import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.declaration.AttributeGroupTree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
@@ -30,14 +32,21 @@ import org.sonar.plugins.php.api.visitors.VisitorCheck;
 
 public class EnumCaseTreeImpl extends PHPTree implements EnumCaseTree {
 
+  private final List<AttributeGroupTree> attributeGroupTrees;
   private final SyntaxToken caseToken;
   private final NameIdentifierTree name;
   private final SyntaxToken eosToken;
 
-  public EnumCaseTreeImpl(SyntaxToken caseToken, NameIdentifierTree name, SyntaxToken eosToken) {
+  public EnumCaseTreeImpl(List<AttributeGroupTree> attributeGroups, SyntaxToken caseToken, NameIdentifierTree name, SyntaxToken eosToken) {
+    this.attributeGroupTrees = attributeGroups;
     this.caseToken = caseToken;
     this.name = name;
     this.eosToken = eosToken;
+  }
+
+  @Override
+  public List<AttributeGroupTree> attributeGroups() {
+    return attributeGroupTrees;
   }
 
   @Override
@@ -57,7 +66,7 @@ public class EnumCaseTreeImpl extends PHPTree implements EnumCaseTree {
 
   @Override
   public Iterator<Tree> childrenIterator() {
-    return IteratorUtils.iteratorOf(caseToken, name, eosToken);
+    return IteratorUtils.concat(attributeGroupTrees.iterator(), IteratorUtils.iteratorOf(caseToken, name, eosToken));
   }
 
   @Override

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/ClassDeclarationTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/ClassDeclarationTree.java
@@ -56,8 +56,8 @@ public interface ClassDeclarationTree extends StatementTree, ClassTree {
   SyntaxToken modifierToken();
 
   /**
-   * Either {@link PHPKeyword#CLASS class}, {@link PHPKeyword#TRAIT trait}
-   * or {@link PHPKeyword#INTERFACE interface}
+   * Either {@link PHPKeyword#CLASS class}, {@link PHPKeyword#TRAIT trait},
+   *  {@link PHPKeyword#INTERFACE interface} or {@link PHPKeyword#ENUM enum}
    */
   @Override
   SyntaxToken classToken();

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/ClassMemberTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/ClassMemberTree.java
@@ -27,6 +27,7 @@ import org.sonar.plugins.php.api.tree.Tree;
  *   <li>{@link Kind#METHOD_DECLARATION Method declaration}
  *   <li>{@link Kind#CLASS_PROPERTY_DECLARATION Class variable declaration}
  *   <li>{@link Kind#USE_TRAIT_DECLARATION Trait use statement}
+ *   <li>{@link Kind#ENUM_CASE Enum case for enum declarations}
  * <ul/>
  */
 public interface ClassMemberTree extends Tree {

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/declaration/EnumDeclarationTree.java
@@ -20,20 +20,41 @@
 package org.sonar.plugins.php.api.tree.declaration;
 
 import java.util.List;
+import javax.annotation.Nullable;
+import org.sonar.plugins.php.api.tree.SeparatedList;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 import org.sonar.plugins.php.api.tree.statement.EnumCaseTree;
-import org.sonar.plugins.php.api.tree.statement.StatementTree;
 
-public interface EnumDeclarationTree extends StatementTree {
+public interface EnumDeclarationTree extends ClassDeclarationTree {
 
-  SyntaxToken enumToken();
+  @Nullable
+  @Override
+  SyntaxToken modifierToken();
 
+  @Override
   NameIdentifierTree name();
 
+  @Nullable
+  @Override
+  SyntaxToken implementsToken();
+
+  @Override
+  SeparatedList<NamespaceNameTree> superInterfaces();
+
+  @Override
   SyntaxToken openCurlyBraceToken();
 
+  @Override
+  List<ClassMemberTree> members();
+
+  /**
+   * The cases of the enumeration.
+   * These are also part of {@link EnumDeclarationTree#members()}
+   */
   List<EnumCaseTree> cases();
 
+  @Override
   SyntaxToken closeCurlyBraceToken();
+
 }

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/statement/EnumCaseTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/statement/EnumCaseTree.java
@@ -20,10 +20,11 @@
 package org.sonar.plugins.php.api.tree.statement;
 
 import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
+import org.sonar.plugins.php.api.tree.declaration.HasAttributes;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 
-public interface EnumCaseTree extends ClassMemberTree {
+public interface EnumCaseTree extends ClassMemberTree, HasAttributes {
 
   SyntaxToken caseToken();
 

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/statement/EnumCaseTree.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/tree/statement/EnumCaseTree.java
@@ -19,11 +19,11 @@
  */
 package org.sonar.plugins.php.api.tree.statement;
 
-import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 
-public interface EnumCaseTree extends Tree {
+public interface EnumCaseTree extends ClassMemberTree {
 
   SyntaxToken caseToken();
 

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/visitors/PHPVisitorCheck.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/visitors/PHPVisitorCheck.java
@@ -36,7 +36,6 @@ import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ConstantDeclarationTree;
-import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.FunctionDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -600,11 +599,6 @@ public abstract class PHPVisitorCheck implements VisitorCheck {
 
   @Override
   public void visitAttribute(AttributeTree tree) {
-    scan(tree);
-  }
-
-  @Override
-  public void visitEnumDeclaration(EnumDeclarationTree tree) {
     scan(tree);
   }
 

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/visitors/VisitorCheck.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/visitors/VisitorCheck.java
@@ -28,7 +28,6 @@ import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassPropertyDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ConstantDeclarationTree;
-import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.FunctionDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -158,8 +157,6 @@ public interface VisitorCheck extends PHPCheck {
   void visitBuiltInType(BuiltInTypeTree tree);
 
   void visitReturnTypeClause(ReturnTypeClauseTree tree);
-
-  void visitEnumDeclaration(EnumDeclarationTree tree);
 
   /**
    * [ END ] Declaration

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
@@ -34,9 +34,12 @@ public class EnumDeclarationTest {
       .matches("enum A {\n case A;\n case B; }")
       .matches("enum A { function foo() {} }")
       .matches("enum A { const CONSTANT = 'foo'; }")
+      .matches("enum A implements B {}")
+      .matches("enum A implements B,C {}")
       .notMatches("enum A {")
       .notMatches("enum A { case A}")
       .notMatches("enum A { public $property; }")
+      .notMatches("enum A extends B { }")
     ;
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
@@ -36,6 +36,7 @@ public class EnumDeclarationTest {
       .matches("enum A { const CONSTANT = 'foo'; }")
       .matches("enum A implements B {}")
       .matches("enum A implements B,C {}")
+      .matches("#[A1(1)] enum A {}")
       .notMatches("enum A {")
       .notMatches("enum A { case A}")
       .notMatches("enum A { public $property; }")

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/EnumDeclarationTest.java
@@ -32,8 +32,11 @@ public class EnumDeclarationTest {
       .matches("enum A {}")
       .matches("enum A { case A; }")
       .matches("enum A {\n case A;\n case B; }")
+      .matches("enum A { function foo() {} }")
+      .matches("enum A { const CONSTANT = 'foo'; }")
       .notMatches("enum A {")
       .notMatches("enum A { case A}")
+      .notMatches("enum A { public $property; }")
     ;
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/parser/statement/EnumCaseTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/statement/EnumCaseTest.java
@@ -30,6 +30,7 @@ public class EnumCaseTest {
   public void test() {
     assertThat(PHPLexicalGrammar.ENUM_CASE)
       .matches("case A;")
+      .matches("#[A1(1)] case A;")
       .notMatches("case A")
     ;
   }

--- a/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
@@ -33,7 +33,7 @@ public class EnumDeclarationTreeTest extends PHPTreeModelTest {
   public void simple_enum_with_no_cases() {
     EnumDeclarationTreeImpl tree = parse("enum A {}", PHPLexicalGrammar.ENUM_DECLARATION);
     assertThat(tree.is(Tree.Kind.ENUM_DECLARATION)).isTrue();
-    assertThat(tree.childrenIterator()).hasSize(4);
+    assertThat(tree.childrenIterator()).hasSize(5);
     assertThat(tree.classToken()).hasToString("enum");
     assertThat(tree.name()).hasToString("A");
     assertThat(tree.openCurlyBraceToken()).hasToString("{");
@@ -62,5 +62,22 @@ public class EnumDeclarationTreeTest extends PHPTreeModelTest {
     assertThat(tree.members().get(0)).isSameAs(tree.cases().get(0));
     assertThat(tree.members().get(1).is(Tree.Kind.CLASS_CONSTANT_PROPERTY_DECLARATION)).isTrue();
     assertThat(tree.members().get(2).is(Tree.Kind.METHOD_DECLARATION)).isTrue();
+  }
+
+  @Test
+  public void enum_can_implement_interfaces() {
+    EnumDeclarationTree tree = parse("enum A implements B,C {}", PHPLexicalGrammar.ENUM_DECLARATION);
+    assertThat(tree.implementsToken()).hasToString("implements");
+    assertThat(tree.superInterfaces()).hasSize(2);
+    assertThat(tree.superInterfaces().get(0)).hasToString("B");
+    assertThat(tree.superInterfaces().get(1)).hasToString("C");
+  }
+
+  @Test
+  public void enum_can_have_attributes() {
+    EnumDeclarationTree tree = parse("#[A1(1)] enum A {}", PHPLexicalGrammar.ENUM_DECLARATION);
+    assertThat(tree.attributeGroups()).hasSize(1);
+    assertThat(tree.attributeGroups().get(0).attributes()).hasSize(1);
+    assertThat(tree.attributeGroups().get(0).attributes().get(0).name()).hasToString("A1");
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/impl/declaration/EnumDeclarationTreeTest.java
@@ -32,13 +32,13 @@ public class EnumDeclarationTreeTest extends PHPTreeModelTest {
   @Test
   public void simple_enum_with_no_cases() {
     EnumDeclarationTreeImpl tree = parse("enum A {}", PHPLexicalGrammar.ENUM_DECLARATION);
-
     assertThat(tree.is(Tree.Kind.ENUM_DECLARATION)).isTrue();
     assertThat(tree.childrenIterator()).hasSize(4);
-    assertThat(tree.enumToken()).hasToString("enum");
+    assertThat(tree.classToken()).hasToString("enum");
     assertThat(tree.name()).hasToString("A");
     assertThat(tree.openCurlyBraceToken()).hasToString("{");
     assertThat(tree.cases()).isEmpty();
+    assertThat(tree.members()).isEmpty();
     assertThat(tree.closeCurlyBraceToken()).hasToString("}");
   }
 
@@ -48,7 +48,19 @@ public class EnumDeclarationTreeTest extends PHPTreeModelTest {
     assertThat(tree.is(Tree.Kind.ENUM_DECLARATION)).isTrue();
     assertThat(tree.name()).hasToString("A");
     assertThat(tree.cases()).hasSize(2);
+    assertThat(tree.members()).hasSize(2);
     assertThat(tree.cases().get(0).name()).hasToString("A");
     assertThat(tree.cases().get(1).name()).hasToString("B");
+  }
+
+  @Test
+  public void enum_can_contain_other_class_like_members() {
+    EnumDeclarationTree tree = parse("enum A {case A;\nconst FOO = 1;\npublic function foo(){} }", PHPLexicalGrammar.ENUM_DECLARATION);
+    assertThat(tree.cases()).hasSize(1);
+    assertThat(tree.cases().get(0).name()).hasToString("A");
+    assertThat(tree.members()).hasSize(3);
+    assertThat(tree.members().get(0)).isSameAs(tree.cases().get(0));
+    assertThat(tree.members().get(1).is(Tree.Kind.CLASS_CONSTANT_PROPERTY_DECLARATION)).isTrue();
+    assertThat(tree.members().get(2).is(Tree.Kind.METHOD_DECLARATION)).isTrue();
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/tree/impl/statement/EnumCaseTreeTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/impl/statement/EnumCaseTreeTest.java
@@ -31,11 +31,18 @@ public class EnumCaseTreeTest extends PHPTreeModelTest {
   @Test
   public void simple_case() {
     EnumCaseTreeImpl tree = parse("case A;", PHPLexicalGrammar.ENUM_CASE);
-
     assertThat(tree.is(Tree.Kind.ENUM_CASE)).isTrue();
     assertThat(tree.childrenIterator()).hasSize(3);
     assertThat(tree.caseToken()).hasToString("case");
     assertThat(tree.name()).hasToString("A");
     assertThat(tree.eosToken()).hasToString(";");
+  }
+
+  @Test
+  public void enum_case_can_have_attributes() {
+    EnumCaseTreeImpl tree = parse("#[A1(1)] case A;", PHPLexicalGrammar.ENUM_CASE);
+    assertThat(tree.attributeGroups()).hasSize(1);
+    assertThat(tree.attributeGroups().get(0).attributes()).hasSize(1);
+    assertThat(tree.attributeGroups().get(0).attributes().get(0).name()).hasToString("A1");
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/tree/visitors/PHPVisitorCheckTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/visitors/PHPVisitorCheckTest.java
@@ -31,7 +31,6 @@ import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.AttributeGroupTree;
 import org.sonar.plugins.php.api.tree.declaration.AttributeTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
-import org.sonar.plugins.php.api.tree.declaration.EnumDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
 import org.sonar.plugins.php.api.tree.declaration.UnionTypeTree;
 import org.sonar.plugins.php.api.tree.expression.BinaryExpressionTree;
@@ -60,7 +59,7 @@ public class PHPVisitorCheckTest {
     TestVisitor testVisitor = new TestVisitor();
     testVisitor.analyze(file, tree);
 
-    assertThat(testVisitor.classCounter).isEqualTo(1);
+    assertThat(testVisitor.classCounter).isEqualTo(2);
     assertThat(testVisitor.namespaceNameCounter).isEqualTo(6);
     assertThat(testVisitor.varIdentifierCounter).isEqualTo(6);
     // PHPCheck#init() is called by PHPAnalyzer
@@ -169,6 +168,9 @@ public class PHPVisitorCheckTest {
     public void visitClassDeclaration(ClassDeclarationTree tree) {
       super.visitClassDeclaration(tree);
       classCounter++;
+      if (tree.is(Tree.Kind.ENUM_DECLARATION)) {
+        enumsCounter++;
+      }
     }
 
     @Override
@@ -227,12 +229,6 @@ public class PHPVisitorCheckTest {
     @Override
     public void visitTrivia(SyntaxTrivia trivia) {
       triviaCounter++;
-    }
-
-    @Override
-    public void visitEnumDeclaration(EnumDeclarationTree tree) {
-      super.visitEnumDeclaration(tree);
-      enumsCounter++;
     }
 
     @Override


### PR DESCRIPTION
Note that I purposefully did remove the `visitEnumDeclaration()` method, even though an enum declaration has its tree `EnumDeclarationTree`. To visit an enum declaration, one would need to use `visitClassDeclaration()`. Reasons:
- We do not have a `visitTraitDeclaration()` or `visitInterfaceDeclaration()` neither. We do use `visitClassDeclaration()` and differentiate by kind **if** necessary.
- Relying on `visitClassDeclaration()` has the advantage that we do not have to go in all the places where `visitClassDeclaration()` is used and think about if we require applying the same logic for enums. Example: scope tracking in symbol table building.

I admit that using `visitClassDeclaration()` for all of this can be confusing. Ideally, we would have something like a `ClassLikeTree` and differentiate classes, interfaces, traits, and enums. However, this would be a big API change, and I see more advantages than disadvantages for using  `visitClassDeclaration()` for enums too. Happy to discuss though :smile: 