### PR TITLE
SONARPHP-1266 Parser should allow "readonly" as function name

### DIFF
--- a/php-frontend/src/main/java/org/sonar/php/api/PHPKeyword.java
+++ b/php-frontend/src/main/java/org/sonar/php/api/PHPKeyword.java
@@ -25,6 +25,7 @@ public enum PHPKeyword implements GrammarRuleKey {
 
   HALT_COMPILER("__halt_compiler"),
   ABSTRACT("abstract"),
+  // First two values should be kept as they are for now until SONARPHP-1267 is handled to avoid regression.
   AND("and"),
   ARRAY("array"),
   AS("as"),

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPLexicalGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPLexicalGrammar.java
@@ -375,7 +375,12 @@ public enum PHPLexicalGrammar implements GrammarRuleKey {
       // PHP keywords are case insensitive
       b.rule(tokenType).is(SPACING, b.regexp("(?i)" + tokenType.getValue()), b.nextNot(b.regexp(LexicalConstant.IDENTIFIER_PART))).skip();
       if (i > 1) {
-        rest[i - 2] = b.regexp("(?i)" + tokenType.getValue());
+        if (tokenType == PHPKeyword.READONLY) {
+          // Readonly is only a keyword when it is not used as a function name. SONARPHP-1266
+          rest[i - 2] = b.sequence(b.regexp("(?i)readonly"), b.nextNot(b.regexp("[\\s]*\\(")));
+        } else {
+          rest[i - 2] = b.regexp("(?i)" + tokenType.getValue());
+        }
       }
     }
 

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/ClassDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/ClassDeclarationTest.java
@@ -40,6 +40,7 @@ public class ClassDeclarationTest {
       .matches("class C extends A implements B {}")
       .matches("#[A1(1)] class C {}")
 
-      .notMatches("class A extends B, C {}");
+      .notMatches("class A extends B, C {}")
+      .notMatches("class readonly {}");
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/FunctionDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/FunctionDeclarationTest.java
@@ -40,6 +40,8 @@ public class FunctionDeclarationTest {
       .matches("function f($prop = new Foo()) {}")
       .matches("function f(A&B $prop): A&B {}")
       .matches("function f(A|B $prop): A|B {}")
+      .matches("function readonly() {}")
+      .matches("function READONLY() {}")
     ;
   }
 }

--- a/php-frontend/src/test/java/org/sonar/php/parser/declaration/FunctionDeclarationTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/parser/declaration/FunctionDeclarationTest.java
@@ -40,8 +40,14 @@ public class FunctionDeclarationTest {
       .matches("function f($prop = new Foo()) {}")
       .matches("function f(A&B $prop): A&B {}")
       .matches("function f(A|B $prop): A|B {}")
+      // readonly is a keyword, but it can be used as a function name
       .matches("function readonly() {}")
       .matches("function READONLY() {}")
+      // TODO: SONARPHP-1267 all keywords should be case-insensitive, so the below is currently falsely allowed
+      .matches("function ABSTRACT() {}")
+      .matches("function __HALT_COMPILER() {}")
+      .notMatches("function abstract() {}")
+      .notMatches("function __halt_compiler() {}")
     ;
   }
 }


### PR DESCRIPTION
During implementation I discovered a small potential mistake in old code. I did create SONARPHP-1267 to capture this, and did add some comments and tests. I'm not 100% yet if there was actually a reason to do it that way, so I'd rather keep this for a future hardening sprint as it has been like this for a long time, has minimal FN impact, and is not related to PHP 8.1.

What was done for `readonly` is similar to what PHP did here https://github.com/php/php-src/commit/76348f3378dbc0c92568380d23a8d75a777ae49c 