### PR TITLE
SONARPHP-1320 Implement file path adjustment for PHPUnit test and coverage reports

### DIFF
--- a/its/plugin/projects/common-rules/reports/phpunit.coverage.xml
+++ b/its/plugin/projects/common-rules/reports/phpunit.coverage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <coverage generated="1394164581">
   <project timestamp="1394164581">
-    <file name="Math.php">
+    <file name="src/Math.php">
       <class name="Example_Math" namespace="global" fullPackage="Example" package="Example">
         <metrics methods="4" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>
       </class>

--- a/its/plugin/projects/phpunit/reports/phpunit.coverage.unknown.xml
+++ b/its/plugin/projects/phpunit/reports/phpunit.coverage.unknown.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <coverage generated="1394164581">
   <project timestamp="1394164581">
-    <file name="Math.php">
+    <file name="/arbitrary/absolute/path/src/Unknown.php">
       <class name="Example_Math" namespace="global" fullPackage="Example" package="Example">
         <metrics methods="4" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>
       </class>
+      <line num="0" type="method" name="add" crap="1" count="1"/>
       <line num="6" type="method" name="add" crap="1" count="1"/>
       <line num="8" type="stmt" count="1"/>
       <line num="11" type="method" name="sub" crap="1" count="10"/>
       <line num="13" type="stmt" count="10"/>
       <line num="16" type="method" name="div" crap="132" count="0"/>
       <line num="18" type="stmt" count="0"/>
+      <line num="100" type="stmt" count="0"/>
       <metrics loc="1" ncloc="1" classes="1" methods="3" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>
     </file>
     <metrics files="1" loc="1" ncloc="1" classes="1" methods="3" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>

--- a/its/plugin/projects/phpunit/reports/phpunit.coverage.windows.xml
+++ b/its/plugin/projects/phpunit/reports/phpunit.coverage.windows.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <coverage generated="1394164581">
   <project timestamp="1394164581">
-    <file name="Math.php">
+    <file name="C:\arbitrary\absolute\path\src\Math.php">
       <class name="Example_Math" namespace="global" fullPackage="Example" package="Example">
         <metrics methods="4" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>
       </class>
+      <line num="0" type="method" name="add" crap="1" count="1"/>
       <line num="6" type="method" name="add" crap="1" count="1"/>
       <line num="8" type="stmt" count="1"/>
       <line num="11" type="method" name="sub" crap="1" count="10"/>
       <line num="13" type="stmt" count="10"/>
       <line num="16" type="method" name="div" crap="132" count="0"/>
       <line num="18" type="stmt" count="0"/>
+      <line num="100" type="stmt" count="0"/>
       <metrics loc="1" ncloc="1" classes="1" methods="3" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>
     </file>
     <metrics files="1" loc="1" ncloc="1" classes="1" methods="3" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>

--- a/its/plugin/projects/phpunit/reports/phpunit.coverage.xml
+++ b/its/plugin/projects/phpunit/reports/phpunit.coverage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <coverage generated="1394164581">
   <project timestamp="1394164581">
-    <file name="Math.php">
+    <file name="/arbitrary/absolute/path/src/Math.php">
       <class name="Example_Math" namespace="global" fullPackage="Example" package="Example">
         <metrics methods="4" coveredmethods="2" conditionals="0" coveredconditionals="0" statements="3" coveredstatements="2" elements="6" coveredelements="4"/>
       </class>

--- a/its/plugin/projects/phpunit/reports/phpunit.tests.unknown.xml
+++ b/its/plugin/projects/phpunit/reports/phpunit.tests.unknown.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="Test Suite" tests="12" assertions="11" failures="7" errors="0" time="8.036518">
-    <testsuite name="Example_MathTest" file="tests/SomeTest.php" fullPackage="Example" package="Example" tests="12" assertions="11" failures="7" errors="0" time="8.036518">
-      <testcase name="testAddSuccess" class="Example_MathTest" file="tests/SomeTest.php" line="20" assertions="1" time="2.006604"/>
-      <testcase name="testSubSuccess" class="Example_MathTest" file="tests/SomeTest.php" line="29" assertions="1" time="0.000842"/>
-      <testcase name="testSubFail" class="Example_MathTest" file="tests/SomeTest.php" line="37" assertions="1" time="2.006533">
+    <testsuite name="Example_MathTest" file="/arbitrary/absolute/path/tests/tests/Unknown.php" fullPackage="Example" package="Example" tests="12" assertions="11" failures="7" errors="0" time="8.036518">
+      <testcase name="testAddSuccess" class="Example_MathTest" file="/arbitrary/absolute/path/tests/SomeTest.php" line="20" assertions="1" time="2.006604"/>
+      <testcase name="testSubSuccess" class="Example_MathTest" file="/arbitrary/absolute/path/tests/tests/SomeTest.php" line="29" assertions="1" time="0.000842"/>
+      <testcase name="testSubFail" class="Example_MathTest" file="/arbitrary/absolute/path/tests/tests/SomeTest.php" line="37" assertions="1" time="2.006533">
         <failure type="PHPUnit_Framework_ExpectationFailedException">PhpUnderControl_Example_MathTest::testSubFail
 Failed asserting that 1 matches expected 0.
 phar://C:/git/sonar-examples/projects/languages/php/php-sonar-runner-unit-tests/.sonar/phpunit-3.7.20.phar/PHPUnit/Framework/Constraint/IsEqual.php:170

--- a/its/plugin/projects/phpunit/reports/phpunit.tests.xml
+++ b/its/plugin/projects/phpunit/reports/phpunit.tests.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
   <testsuite name="Test Suite" tests="12" assertions="11" failures="7" errors="0" time="8.036518">
-    <testsuite name="Example_MathTest" file="SomeTest.php" fullPackage="Example" package="Example" tests="12" assertions="11" failures="7" errors="0" time="8.036518">
-      <testcase name="testAddSuccess" class="Example_MathTest" file="SomeTest.php" line="20" assertions="1" time="2.006604"/>
-      <testcase name="testSubSuccess" class="Example_MathTest" file="SomeTest.php" line="29" assertions="1" time="0.000842"/>
-      <testcase name="testSubFail" class="Example_MathTest" file="SomeTest.php" line="37" assertions="1" time="2.006533">
+    <testsuite name="Example_MathTest" file="/arbitrary/absolute/path/tests/tests/SomeTest.php" fullPackage="Example" package="Example" tests="12" assertions="11" failures="7" errors="0" time="8.036518">
+      <testcase name="testAddSuccess" class="Example_MathTest" file="/arbitrary/absolute/path/tests/SomeTest.php" line="20" assertions="1" time="2.006604"/>
+      <testcase name="testSubSuccess" class="Example_MathTest" file="/arbitrary/absolute/path/tests/tests/SomeTest.php" line="29" assertions="1" time="0.000842"/>
+      <testcase name="testSubFail" class="Example_MathTest" file="/arbitrary/absolute/path/tests/tests/SomeTest.php" line="37" assertions="1" time="2.006533">
         <failure type="PHPUnit_Framework_ExpectationFailedException">PhpUnderControl_Example_MathTest::testSubFail
 Failed asserting that 1 matches expected 0.
 phar://C:/git/sonar-examples/projects/languages/php/php-sonar-runner-unit-tests/.sonar/phpunit-3.7.20.phar/PHPUnit/Framework/Constraint/IsEqual.php:170

--- a/its/plugin/tests/src/test/java/com/sonar/it/php/CommonRulesTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/php/CommonRulesTest.java
@@ -19,8 +19,6 @@
  */
 package com.sonar.it.php;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
@@ -47,8 +45,6 @@ public class CommonRulesTest {
 
   @BeforeClass
   public static void startServer() throws Exception {
-    createReportsWithAbsolutePath();
-
     Tests.provisionProject(PROJECT_KEY, PROJECT_NAME, "php", "it-profile");
     SonarScanner build = SonarScanner.create()
       .setProjectDir(PROJECT_DIR)
@@ -57,8 +53,8 @@ public class CommonRulesTest {
       .setProjectVersion("1.0")
       .setSourceDirs(SOURCE_DIR)
       .setTestDirs(TESTS_DIR)
-      .setProperty("sonar.php.coverage.reportPaths", REPORTS_DIR + "/.coverage-with-absolute-path.xml")
-      .setProperty("sonar.php.tests.reportPath", REPORTS_DIR + "/.tests-with-absolute-path.xml");
+      .setProperty("sonar.php.coverage.reportPaths", REPORTS_DIR + "/phpunit.coverage.xml")
+      .setProperty("sonar.php.tests.reportPath", REPORTS_DIR + "/phpunit.xml");
 
     Tests.executeBuildWithExpectedWarnings(orchestrator, build);
   }
@@ -72,24 +68,6 @@ public class CommonRulesTest {
     assertThat(Tests.issuesForRule(issues,"common-php:FailedUnitTests")).hasSize(1);
     assertThat(Tests.issuesForRule(issues,"common-php:InsufficientLineCoverage")).hasSize(1);
     assertThat(Tests.issuesForRule(issues,"php:S3334")).hasSize(1);
-  }
-
-  /**
-   * Replace file name with absolute path in test and coverage report.
-   * <p/>
-   * This hack allow to have this integration test, as only absolute path
-   * in report is supported.
-   */
-  private static void createReportsWithAbsolutePath() throws Exception {
-    Files.write(
-      Files.toString(new File(PROJECT_DIR, REPORTS_DIR + "/phpunit.coverage.xml"), Charsets.UTF_8)
-        .replace("Math.php", new File(PROJECT_DIR, SOURCE_DIR + "/Math.php").getAbsolutePath()),
-      new File(PROJECT_DIR, REPORTS_DIR + "/.coverage-with-absolute-path.xml"), Charsets.UTF_8);
-
-    Files.write(
-      Files.toString(new File(PROJECT_DIR, REPORTS_DIR + "/phpunit.xml"), Charsets.UTF_8)
-        .replace("SomeTest.php", new File(PROJECT_DIR, TESTS_DIR + "/SomeTest.php").getAbsolutePath()),
-      new File(PROJECT_DIR, REPORTS_DIR + "/.tests-with-absolute-path.xml"), Charsets.UTF_8);
   }
 
 }

--- a/its/plugin/tests/src/test/java/com/sonar/it/php/PHPUnitLegacyTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/php/PHPUnitLegacyTest.java
@@ -26,7 +26,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import static com.sonar.it.php.PHPUnitTest.createReportsWithAbsolutePath;
 import static com.sonar.it.php.Tests.ORCHESTRATOR;
 import static com.sonar.it.php.Tests.getMeasureAsInt;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,8 +44,7 @@ public class PHPUnitLegacyTest {
   private static final String REPORTS_DIR = "reports";
 
   @BeforeClass
-  public static void startServer() throws Exception {
-    createReportsWithAbsolutePath();
+  public static void startServer() {
 
     Tests.provisionProject(PROJECT_KEY, PROJECT_NAME, "php", "it-profile");
     SonarScanner build = SonarScanner.create()
@@ -56,7 +54,7 @@ public class PHPUnitLegacyTest {
       .setProjectVersion("1.0")
       .setSourceDirs(SOURCE_DIR)
       .setTestDirs(TESTS_DIR)
-      .setProperty("sonar.php.tests.reportPath", REPORTS_DIR + "/.tests-with-absolute-path.xml");
+      .setProperty("sonar.php.tests.reportPath", REPORTS_DIR + "/phpunit.tests.xml");
     Tests.executeBuildWithExpectedWarnings(orchestrator, build);
   }
 

--- a/its/plugin/tests/src/test/java/com/sonar/it/php/ReportWithUnresolvedPathTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/php/ReportWithUnresolvedPathTest.java
@@ -24,7 +24,6 @@ import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SonarScanner;
 import java.io.File;
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -55,9 +54,7 @@ public class ReportWithUnresolvedPathTest {
       .setProperty("sonar.php.coverage.reportPaths", "reports/phpunit.coverage.unknown.xml");
     BuildResult result = orchestrator.executeBuild(build);
 
-    Pattern coverageWarningPattern = Pattern.compile("Failed to resolve 1 file path\\(s\\) in PHPUnit coverage " +
-      "phpunit\\.coverage\\.xml report\\. Nothing is imported related to file\\(s\\): Math\\.php");
-    Predicate<String> coverageWarning = s -> coverageWarningPattern.matcher(s).find();
+    Predicate<String> coverageWarning = s -> s.contains("Failed to resolve 1 file path(s) in PHPUnit coverage phpunit.coverage.unknown.xml report.");
 
     assertThat(result.getLogsLines(WARNING).stream().anyMatch(coverageWarning)).isTrue();
     assertThat(getAnalysisWarnings(PROJECT_NAME).stream().anyMatch(coverageWarning)).isTrue();

--- a/its/plugin/tests/src/test/java/com/sonar/it/php/ReportWithUnresolvedPathTest.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/php/ReportWithUnresolvedPathTest.java
@@ -52,7 +52,7 @@ public class ReportWithUnresolvedPathTest {
       .setProjectVersion("1.0")
       .setSourceDirs("src")
       .setTestDirs("tests")
-      .setProperty("sonar.php.coverage.reportPaths", "reports/phpunit.coverage.xml");
+      .setProperty("sonar.php.coverage.reportPaths", "reports/phpunit.coverage.unknown.xml");
     BuildResult result = orchestrator.executeBuild(build);
 
     Pattern coverageWarningPattern = Pattern.compile("Failed to resolve 1 file path\\(s\\) in PHPUnit coverage " +

--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/ExternalReportFileHandler.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/ExternalReportFileHandler.java
@@ -1,0 +1,104 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.php;
+
+import java.io.File;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.sensor.SensorContext;
+
+/**
+ * This handler allows to convert file paths from external reports into a path relative to the project.
+ * This allows processing the report and linking files in the analyzer context file system and the files named in the report.
+ * This step is necessary because the context in which the report was created and the analyzer context may differ.
+ */
+public class ExternalReportFileHandler {
+
+  private final FileSystem fileSystem;
+
+  private int relativePathOffset = 0;
+
+  private ExternalReportFileHandler(FileSystem fileSystem) {
+    this.fileSystem = fileSystem;
+  }
+
+  public static ExternalReportFileHandler create(SensorContext context) {
+    return new ExternalReportFileHandler(context.fileSystem());
+  }
+
+  /**
+   * First, the file path is adjusted to the file system of the analyzer. If a file with the file name is known to the
+   * file system of the analyzer context, it will not be adjusted further. If it is not known, the file name is decreased
+   * by one folder level to get the correct relative path to the project. This adjustment is then also tried to be applied
+   * to subsequent file paths.
+   */
+  public String relativePath(String path) {
+    // Adapt file path separator to the analyzer context separator
+    String separatorsAdjustedPath = separatorsToSystem(path);
+
+    // If given path is known by the file system, we don't need to adjust the path
+    if (knownFile(separatorsAdjustedPath)) {
+      return separatorsAdjustedPath;
+    }
+
+    String newPath;
+    // If we already calculated the offset of the relative path we can apply it to the other paths
+    if (relativePathOffset > 0) {
+      newPath = separatorsAdjustedPath.substring(relativePathOffset);
+      return knownFile(newPath) ? newPath : separatorsAdjustedPath;
+    }
+
+    newPath = separatorsAdjustedPath;
+    // Reduce the file path by directories until the path is relative to the project directory and known by the file system
+    do {
+      // Skip possible first file separator because it could be part of some absolute paths
+      newPath = newPath.substring(newPath.indexOf(File.separatorChar, 1) + 1);
+      if (knownFile(newPath)) {
+        relativePathOffset = separatorsAdjustedPath.indexOf(newPath);
+        return newPath;
+      }
+    } while (newPath.contains(File.separator));
+
+    return path;
+  }
+
+  /**
+   * Changes the path from the report accordingly for the file system of the analyzer context.
+   * Thus, analyzer and report creation can take place on different file systems.
+   * Inspired by <a href="https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html#separatorsToSystem-java.lang.String-">
+   * org.apache.commons.io.FilenameUtils::separatorsToSystem</a>
+   */
+  private static String separatorsToSystem(String path) {
+    if (File.separatorChar=='\\') {
+      // From Windows to Linux/Mac
+      return path.replace('/', File.separatorChar);
+    } else {
+      // From Linux/Mac to Windows
+      return path.replace('\\', File.separatorChar);
+    }
+  }
+
+  /**
+   * Checks whether a file exists in the analyzer file system for the specified path.
+   */
+  private boolean knownFile(String path) {
+    return fileSystem.hasFiles(fileSystem.predicates().hasPath(path));
+  }
+
+}

--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/ExternalReportFileHandler.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/ExternalReportFileHandler.java
@@ -49,19 +49,26 @@ public class ExternalReportFileHandler {
    * to subsequent file paths.
    */
   public String relativePath(String path) {
+    if (isKnownFile(path)) {
+      return path;
+    }
+
     // Adapt file path separator to the analyzer context separator
     String separatorsAdjustedPath = separatorsToSystem(path);
 
     // If given path is known by the file system, we don't need to adjust the path
-    if (knownFile(separatorsAdjustedPath)) {
+    if (isKnownFile(separatorsAdjustedPath)) {
       return separatorsAdjustedPath;
     }
 
     String newPath;
     // If we already calculated the offset of the relative path we can apply it to the other paths
     if (relativePathOffset > 0) {
+      if (separatorsAdjustedPath.length() < relativePathOffset) {
+        return path;
+      }
       newPath = separatorsAdjustedPath.substring(relativePathOffset);
-      return knownFile(newPath) ? newPath : path;
+      return isKnownFile(newPath) ? newPath : path;
     }
 
     newPath = separatorsAdjustedPath;
@@ -69,7 +76,7 @@ public class ExternalReportFileHandler {
     do {
       // Skip possible first file separator because it could be part of some absolute paths
       newPath = newPath.substring(newPath.indexOf(File.separatorChar, 1) + 1);
-      if (knownFile(newPath)) {
+      if (isKnownFile(newPath)) {
         relativePathOffset = separatorsAdjustedPath.indexOf(newPath);
         return newPath;
       }
@@ -97,7 +104,7 @@ public class ExternalReportFileHandler {
   /**
    * Checks whether a file exists in the analyzer file system for the specified path.
    */
-  private boolean knownFile(String path) {
+  private boolean isKnownFile(String path) {
     return fileSystem.hasFiles(fileSystem.predicates().hasPath(path));
   }
 

--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/ExternalReportFileHandler.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/ExternalReportFileHandler.java
@@ -61,7 +61,7 @@ public class ExternalReportFileHandler {
     // If we already calculated the offset of the relative path we can apply it to the other paths
     if (relativePathOffset > 0) {
       newPath = separatorsAdjustedPath.substring(relativePathOffset);
-      return knownFile(newPath) ? newPath : separatorsAdjustedPath;
+      return knownFile(newPath) ? newPath : path;
     }
 
     newPath = separatorsAdjustedPath;

--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/CoverageResultImporter.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/CoverageResultImporter.java
@@ -95,7 +95,7 @@ public class CoverageResultImporter extends PhpUnitReportImporter {
   private void saveCoverageMeasure(FileNode fileNode, SensorContext context) {
     FileSystem fileSystem = context.fileSystem();
     // PHP supports only absolute paths
-    String path = fileNode.getName();
+    String path = fileHandler.relativePath(fileNode.getName());
     InputFile inputFile = fileSystem.inputFile(fileSystem.predicates().hasPath(path));
 
     // Due to an unexpected behaviour in phpunit.coverage.xml containing references to covered source files, we have to check that the

--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/PhpUnitReportImporter.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/PhpUnitReportImporter.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
+import org.sonar.plugins.php.ExternalReportFileHandler;
 import org.sonar.plugins.php.warning.AnalysisWarningsWrapper;
 import org.sonarsource.analyzer.commons.ExternalReportProvider;
 import org.sonarsource.analyzer.commons.xml.ParseException;
@@ -37,6 +38,7 @@ public abstract class PhpUnitReportImporter implements ReportImporter {
   protected final Set<String> unresolvedInputFiles = new LinkedHashSet<>();
 
   protected AnalysisWarningsWrapper analysisWarningsWrapper;
+  protected ExternalReportFileHandler fileHandler;
 
   protected PhpUnitReportImporter(AnalysisWarningsWrapper analysisWarningsWrapper) {
     this.analysisWarningsWrapper = analysisWarningsWrapper;
@@ -44,6 +46,7 @@ public abstract class PhpUnitReportImporter implements ReportImporter {
 
   @Override
   public final void execute(SensorContext context) {
+    fileHandler = ExternalReportFileHandler.create(context);
     List<File> reportFiles = reportFiles(context);
     reportFiles.forEach(report -> {
       unresolvedInputFiles.clear();

--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/TestFileReport.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/TestFileReport.java
@@ -28,6 +28,7 @@ import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.measures.CoreMetrics;
+import org.sonar.plugins.php.ExternalReportFileHandler;
 import org.sonar.plugins.php.api.Php;
 import org.sonar.plugins.php.phpunit.xml.TestCase;
 
@@ -50,7 +51,8 @@ public class TestFileReport {
     this.testDuration = testDuration;
   }
 
-  public void saveTestMeasures(SensorContext context, Set<String> unresolvedInputFiles) {
+  public void saveTestMeasures(SensorContext context, ExternalReportFileHandler fileHandler, Set<String> unresolvedInputFiles) {
+    file = fileHandler.relativePath(file);
     InputFile unitTestFile = getUnitTestInputFile(context.fileSystem());
     if (unitTestFile != null) {
       context.<Integer>newMeasure().on(unitTestFile).withValue(skipped).forMetric(CoreMetrics.SKIPPED_TESTS).save();

--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/TestResultImporter.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/phpunit/TestResultImporter.java
@@ -46,7 +46,7 @@ public class TestResultImporter extends PhpUnitReportImporter {
     LOG.info("Importing {}", reportFile);
     TestSuites testSuites = parser.parse(reportFile);
     for (TestFileReport fileReport : testSuites.arrangeSuitesIntoTestFileReports()) {
-      fileReport.saveTestMeasures(context, unresolvedInputFiles);
+      fileReport.saveTestMeasures(context, fileHandler, unresolvedInputFiles);
     }
   }
 

--- a/sonar-php-plugin/src/test/java/org/sonar/plugins/php/ExternalReportFileHandlerTest.java
+++ b/sonar-php-plugin/src/test/java/org/sonar/plugins/php/ExternalReportFileHandlerTest.java
@@ -78,6 +78,12 @@ public class ExternalReportFileHandlerTest {
   }
 
   @Test
+  public void test() {
+    assertThat(fileHandler.relativePath(path("unknown", "index.php"))).isEqualTo(path("index.php"));
+    assertThat(fileHandler.relativePath("index.php")).isEqualTo("index.php");
+  }
+
+  @Test
   public void should_return_relative_path_for_second_file_when_unknown() {
     assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "index.php"))).isEqualTo("index.php");
     assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "subfolder", "unknown.php"))).isEqualTo(path("foo", "bar", "FileHandler", "subfolder", "unknown.php"));
@@ -90,9 +96,21 @@ public class ExternalReportFileHandlerTest {
   }
 
   @Test
-  public void should_return_relative_path_for_windows_path() {
+  public void should_return_relative_path_for_fqn_windows_path() {
     assertThat(fileHandler.relativePath("C:\\foo\\bar\\FileHandler\\index.php")).isEqualTo("index.php");
     assertThat(fileHandler.relativePath("C:\\foo\\bar\\FileHandler\\subfolder\\index.php")).isEqualTo(path("subfolder", "index.php"));
+  }
+
+  @Test
+  public void should_return_relative_path_for_relative_windows_path() {
+    assertThat(fileHandler.relativePath("index.php")).isEqualTo("index.php");
+    assertThat(fileHandler.relativePath("subfolder\\index.php")).isEqualTo("subfolder\\index.php");
+  }
+
+  @Test
+  public void should_return_handle_shorter_path() {
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "index.php"))).isEqualTo("index.php");
+    assertThat(fileHandler.relativePath(path("bar",  "index.php"))).isEqualTo(path("bar","index.php"));
   }
 
 

--- a/sonar-php-plugin/src/test/java/org/sonar/plugins/php/ExternalReportFileHandlerTest.java
+++ b/sonar-php-plugin/src/test/java/org/sonar/plugins/php/ExternalReportFileHandlerTest.java
@@ -1,0 +1,108 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.php;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExternalReportFileHandlerTest {
+
+  private static final Path PROJECT_DIR = Paths.get("src", "test", "resources", "FileHandler");
+  private static final String MODULE_KEY = "ExternalReportFileHandler";
+
+  private ExternalReportFileHandler fileHandler;
+
+  private SensorContextTester context;
+
+  @Before
+  public void setup() {
+    context =  SensorContextTester.create(PROJECT_DIR);
+    addInputFiles("index.php", "subfolder/index.php");
+    fileHandler = ExternalReportFileHandler.create(context);
+  }
+
+  @Test
+  public void should_return_relative_path_when_all_files_are_known() {
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "index.php"))).isEqualTo("index.php");
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "subfolder", "index.php"))).isEqualTo(path("subfolder", "index.php"));
+  }
+
+  @Test
+  public void should_return_relative_path_when_first_file_is_in_subfolder() {
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "subfolder", "index.php"))).isEqualTo(path("subfolder", "index.php"));
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "index.php"))).isEqualTo("index.php");
+  }
+
+
+  @Test
+  public void should_not_return_relative_when_files_are_unknown() {
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "unknown.php"))).isEqualTo(path("foo", "bar", "FileHandler", "unknown.php"));
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "subfolder", "unknown.php"))).isEqualTo(path("foo", "bar", "FileHandler", "subfolder", "unknown.php"));
+  }
+
+  @Test
+  public void should_return_relative_when_first_file_is_unknown() {
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "unknown.php"))).isEqualTo(path("foo", "bar", "FileHandler", "unknown.php"));
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "subfolder", "index.php"))).isEqualTo(path("subfolder", "index.php"));
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "index.php"))).isEqualTo("index.php");
+  }
+
+  @Test
+  public void should_return_relative_path_when_already_relative() {
+    assertThat(fileHandler.relativePath("index.php")).isEqualTo("index.php");
+    assertThat(fileHandler.relativePath(path("subfolder", "index.php"))).isEqualTo(path("subfolder", "index.php"));
+  }
+
+  @Test
+  public void should_return_relative_path_for_second_file_when_unknown() {
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "index.php"))).isEqualTo("index.php");
+    assertThat(fileHandler.relativePath(path("foo", "bar", "FileHandler", "subfolder", "unknown.php"))).isEqualTo(path("foo", "bar", "FileHandler", "subfolder", "unknown.php"));
+  }
+
+  @Test
+  public void should_return_relative_path_for_unix_path() {
+    assertThat(fileHandler.relativePath("/foo/bar/FileHandler/index.php")).isEqualTo("index.php");
+    assertThat(fileHandler.relativePath("/foo/bar/FileHandler/subfolder/index.php")).isEqualTo(path("subfolder", "index.php"));
+  }
+
+  @Test
+  public void should_return_relative_path_for_windows_path() {
+    assertThat(fileHandler.relativePath("C:\\foo\\bar\\FileHandler\\index.php")).isEqualTo("index.php");
+    assertThat(fileHandler.relativePath("C:\\foo\\bar\\FileHandler\\subfolder\\index.php")).isEqualTo(path("subfolder", "index.php"));
+  }
+
+
+  private void addInputFiles(String... paths) {
+    Arrays.stream(paths).forEach(path -> context.fileSystem().add(TestInputFileBuilder.create(MODULE_KEY, path).build()));
+  }
+
+  private static String path(String first, String... more) {
+    return Path.of(first, more).toString();
+  }
+
+
+}

--- a/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/CoverageResultImporterTest.java
+++ b/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/CoverageResultImporterTest.java
@@ -50,7 +50,6 @@ public class CoverageResultImporterTest {
   private static final String BASE_DIR = "/org/sonar/plugins/php/phpunit/sensor/";
   private static final String MONKEY_FILE_NAME = "src/Monkey.php";
   private static final String SRC_TEST_RESOURCES = "src/test/resources/";
-  private static final char SEPARATOR_CHAR = File.separatorChar;
   private final AnalysisWarningsWrapper analysisWarnings = spy(AnalysisWarningsWrapper.class);
 
   private CoverageResultImporter importer;
@@ -118,10 +117,22 @@ public class CoverageResultImporterTest {
 
   @Test
   public void should_generate_coverage_measures_with_fqn_paths() {
-    String warning = "Failed to resolve 2 file path(s) in PHPUnit coverage "+reportPath("phpunit.coverage-fqn.xml")+" report. " +
-      "Nothing is imported related to file(s): "+osIndependentPath("/foo/bar/src/Banana.php;/foo/bar/src/IndexControllerTest.php");
+    String warning = "Failed to resolve 2 file path(s) in PHPUnit coverage phpunit.coverage-fqn.xml report. " +
+      "Nothing is imported related to file(s): /foo/bar/src/Banana.php;/foo/bar/src/IndexControllerTest.php";
 
-    executeSensorImporting(getReportFile(reportPath("phpunit.coverage-fqn.xml")));
+    executeSensorImporting(getReportFile("phpunit.coverage-fqn.xml"));
+    assertReport(componentKey(MONKEY_FILE_NAME));
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsExactly(warning);
+
+    verify(analysisWarnings, times(1)).addWarning(warning);
+  }
+
+  @Test
+  public void should_generate_coverage_measures_with_windows_fqn_paths() {
+    String warning = "Failed to resolve 2 file path(s) in PHPUnit coverage phpunit.coverage-fqn_win.xml report. " +
+      "Nothing is imported related to file(s): C:\\foo\\bar\\src\\Banana.php;C:\\foo\\bar\\src\\IndexControllerTest.php";
+
+    executeSensorImporting(getReportFile("phpunit.coverage-fqn_win.xml"));
     assertReport(componentKey(MONKEY_FILE_NAME));
     assertThat(logTester.logs(LoggerLevel.WARN)).containsExactly(warning);
 
@@ -190,24 +201,5 @@ public class CoverageResultImporterTest {
 
   private static String componentKey(String componentName) {
     return "moduleKey:" + componentName;
-  }
-
-  private static String osIndependentPath(String path){
-    if (SEPARATOR_CHAR =='\\'){
-      path =  path.replace("/", "\\");
-    }
-    return path;
-  }
-
-  private static String reportPath(String path){
-
-    if (SEPARATOR_CHAR == '\\'){
-      path =  path.replace("/", "\\");
-      StringBuilder builder = new StringBuilder(path);
-      int index = builder.lastIndexOf(".");
-      builder.replace(index, index+1, "_win.");
-      return builder.toString();
-    }
-    return path;
   }
 }

--- a/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/CoverageResultImporterTest.java
+++ b/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/CoverageResultImporterTest.java
@@ -19,17 +19,13 @@
  */
 package org.sonar.plugins.php.phpunit;
 
-import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
@@ -37,6 +33,7 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.utils.log.LogTester;
 import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.plugins.php.ExternalReportFileHandler;
 import org.sonar.plugins.php.PhpTestUtils;
 import org.sonar.plugins.php.api.Php;
 import org.sonar.plugins.php.warning.AnalysisWarningsWrapper;
@@ -52,10 +49,8 @@ public class CoverageResultImporterTest {
 
   private static final String BASE_DIR = "/org/sonar/plugins/php/phpunit/sensor/";
   private static final String MONKEY_FILE_NAME = "src/Monkey.php";
-  private static final String BANANA_FILE_NAME = "src/Banana.php";
   private static final String SRC_TEST_RESOURCES = "src/test/resources/";
-  private static final File MONKEY_FILE = new File(SRC_TEST_RESOURCES + BASE_DIR + MONKEY_FILE_NAME);
-  private static final File BANANA_FILE = new File(SRC_TEST_RESOURCES + BASE_DIR + BANANA_FILE_NAME);
+  private static final char SEPARATOR_CHAR = File.separatorChar;
   private final AnalysisWarningsWrapper analysisWarnings = spy(AnalysisWarningsWrapper.class);
 
   private CoverageResultImporter importer;
@@ -66,9 +61,6 @@ public class CoverageResultImporterTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
 
   @Before
   public void setUp() {
@@ -82,6 +74,7 @@ public class CoverageResultImporterTest {
     context.fileSystem().add(monkeyFile);
 
     importer = new CoverageResultImporter(analysisWarnings);
+    importer.fileHandler = ExternalReportFileHandler.create(context);
   }
 
   @Test
@@ -100,14 +93,14 @@ public class CoverageResultImporterTest {
   public void should_parse_even_with_package_node() throws Exception {
     String componentKey = componentKey(MONKEY_FILE_NAME);
 
-    importer.importReport(getReportsWithAbsolutePath("phpunit.coverage-with-package.xml"), context);
+    importer.importReport(getReportFile("phpunit.coverage-with-package.xml"), context);
 
     assertCoverageLineHits(context, componentKey, 34, 1);
   }
 
   @Test
   public void should_generate_coverage_measures_also_with_missing_files() throws Exception {
-    executeSensorImporting(getReportsWithAbsolutePath("phpunit.coverage.xml"));
+    executeSensorImporting(getReportFile("phpunit.coverage.xml"));
     String componentKey = componentKey(MONKEY_FILE_NAME);
     assertReport(componentKey);
     assertThat(logTester.logs(LoggerLevel.WARN)).hasSize(3);
@@ -124,13 +117,15 @@ public class CoverageResultImporterTest {
   }
 
   @Test
-  public void should_work_with_relative_paths() throws Exception {
-    String componentKey = componentKey(MONKEY_FILE_NAME);
+  public void should_generate_coverage_measures_with_fqn_paths() {
+    String warning = "Failed to resolve 2 file path(s) in PHPUnit coverage "+reportPath("phpunit.coverage-fqn.xml")+" report. " +
+      "Nothing is imported related to file(s): "+osIndependentPath("/foo/bar/src/Banana.php;/foo/bar/src/IndexControllerTest.php");
 
-    String reportName = "phpunit.coverage.xml";
-    File reportFile = Paths.get(SRC_TEST_RESOURCES, PhpTestUtils.PHPUNIT_REPORT_DIR, reportName).toFile();
-    importer.importReport(reportFile, context);
-    assertReport(componentKey);
+    executeSensorImporting(getReportFile(reportPath("phpunit.coverage-fqn.xml")));
+    assertReport(componentKey(MONKEY_FILE_NAME));
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsExactly(warning);
+
+    verify(analysisWarnings, times(1)).addWarning(warning);
   }
 
   private void assertReport(String componentKey) {
@@ -152,7 +147,7 @@ public class CoverageResultImporterTest {
   public void should_not_fail_if_no_statement_count() throws Exception {
     String componentKey = componentKey(MONKEY_FILE_NAME);
 
-    importer.importReport(getReportsWithAbsolutePath("phpunit.coverage-with-no-statements-covered.xml"), context);
+    importer.importReport(getReportFile("phpunit.coverage-with-no-statements-covered.xml"), context);
 
     assertCoverageLineHits(context, componentKey, 31, 0);
   }
@@ -163,7 +158,7 @@ public class CoverageResultImporterTest {
   @Test
   public void should_not_fail_if_no_line_for_file_node() throws Exception {
     try {
-      importer.importReport(getReportsWithAbsolutePath("phpunit.coverage-with-filenode-without-line.xml"), context);
+      importer.importReport(getReportFile("phpunit.coverage-with-filenode-without-line.xml"), context);
     } catch (Exception e) {
       fail("Shound never happen");
     }
@@ -173,29 +168,15 @@ public class CoverageResultImporterTest {
   public void should_not_set_metrics_to_ncloc_for_missing_files_sq_62() throws Exception {
     String componentKey = componentKey("Monkey.php");
 
-    importer.importReport(getReportsWithAbsolutePath("phpunit.coverage-empty.xml"), context);
+    importer.importReport(getReportFile("phpunit.coverage-empty.xml"), context);
 
     // since SQ 6.2 these are not saved
     assertThat(context.measure(componentKey, CoreMetrics.LINES_TO_COVER)).isNull();
     assertThat(context.measure(componentKey, CoreMetrics.UNCOVERED_LINES)).isNull();
   }
 
-  /**
-   * Replace file name with absolute path in coverage report.
-   *
-   * This hack allow to have this unit test, as only absolute path
-   * in report is supported.
-   * */
-  private File getReportsWithAbsolutePath(String reportName) throws Exception {
-    File fileWIthAbsolutePaths = folder.newFile("report_with_absolute_paths.xml");
-
-    Files.write(
-      Files.toString(new File(SRC_TEST_RESOURCES + PhpTestUtils.PHPUNIT_REPORT_DIR + reportName), StandardCharsets.UTF_8)
-        .replace(MONKEY_FILE_NAME, MONKEY_FILE.getAbsolutePath())
-        .replace(BANANA_FILE_NAME, BANANA_FILE.getAbsolutePath()),
-      fileWIthAbsolutePaths, StandardCharsets.UTF_8);
-
-    return fileWIthAbsolutePaths;
+  private static File getReportFile(String file) {
+    return new File(SRC_TEST_RESOURCES + BASE_DIR + file);
   }
 
   private void executeSensorImporting(File fileName) {
@@ -211,4 +192,22 @@ public class CoverageResultImporterTest {
     return "moduleKey:" + componentName;
   }
 
+  private static String osIndependentPath(String path){
+    if (SEPARATOR_CHAR =='\\'){
+      path =  path.replace("/", "\\");
+    }
+    return path;
+  }
+
+  private static String reportPath(String path){
+
+    if (SEPARATOR_CHAR == '\\'){
+      path =  path.replace("/", "\\");
+      StringBuilder builder = new StringBuilder(path);
+      int index = builder.lastIndexOf(".");
+      builder.replace(index, index+1, "_win.");
+      return builder.toString();
+    }
+    return path;
+  }
 }

--- a/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/TestFileReportTest.java
+++ b/sonar-php-plugin/src/test/java/org/sonar/plugins/php/phpunit/TestFileReportTest.java
@@ -29,6 +29,7 @@ import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.measures.CoreMetrics;
+import org.sonar.plugins.php.ExternalReportFileHandler;
 import org.sonar.plugins.php.PhpTestUtils;
 import org.sonar.plugins.php.api.Php;
 import org.sonar.plugins.php.phpunit.xml.TestCase;
@@ -42,6 +43,8 @@ public class TestFileReportTest {
   private SensorContextTester context;
   private Set<String> unresolvedInputFiles;
 
+  private ExternalReportFileHandler fileHandler;
+
   @Before
   public void setUp() throws Exception {
     testFileName = "testfile.php";
@@ -50,6 +53,7 @@ public class TestFileReportTest {
     context.fileSystem().add(testFile);
     componentKey = testFile.key();
     unresolvedInputFiles = new LinkedHashSet<>();
+    fileHandler = ExternalReportFileHandler.create(context);
   }
 
   @Test
@@ -59,7 +63,7 @@ public class TestFileReportTest {
     report.addTestCase(new TestCase(TestCase.Status.ERROR));
     report.addTestCase(new TestCase(TestCase.Status.FAILURE));
     report.addTestCase(new TestCase(TestCase.Status.FAILURE));
-    report.saveTestMeasures(context, unresolvedInputFiles);
+    report.saveTestMeasures(context, fileHandler, unresolvedInputFiles);
     PhpTestUtils.assertMeasure(context, componentKey, CoreMetrics.TEST_EXECUTION_TIME, 3000l);
     PhpTestUtils.assertMeasure(context, componentKey, CoreMetrics.SKIPPED_TESTS, 1);
     PhpTestUtils.assertMeasure(context, componentKey, CoreMetrics.TEST_ERRORS, 1);
@@ -70,7 +74,7 @@ public class TestFileReportTest {
   @Test
   public void shouldReportZeroTestsIfEmpty() throws Exception {
     final TestFileReport report = new TestFileReport(testFileName, 0d);
-    report.saveTestMeasures(context, unresolvedInputFiles);
+    report.saveTestMeasures(context, fileHandler, unresolvedInputFiles);
     PhpTestUtils.assertMeasure(context, componentKey, CoreMetrics.TESTS, 0);
     assertThat(unresolvedInputFiles).isEmpty();
   }
@@ -82,7 +86,7 @@ public class TestFileReportTest {
     report.addTestCase(new TestCase(TestCase.Status.SKIPPED));
     report.addTestCase(new TestCase(TestCase.Status.FAILURE));
     report.addTestCase(new TestCase(TestCase.Status.ERROR));
-    report.saveTestMeasures(context, unresolvedInputFiles);
+    report.saveTestMeasures(context, fileHandler, unresolvedInputFiles);
     PhpTestUtils.assertMeasure(context, componentKey, CoreMetrics.TESTS, 3);
     assertThat(unresolvedInputFiles).isEmpty();
   }

--- a/sonar-php-plugin/src/test/resources/FileHandler/index.php
+++ b/sonar-php-plugin/src/test/resources/FileHandler/index.php
@@ -1,0 +1,5 @@
+<?php
+function foo(int $i) {
+  echo $i;
+}
+foo("not an int");

--- a/sonar-php-plugin/src/test/resources/FileHandler/subfolder/index.php
+++ b/sonar-php-plugin/src/test/resources/FileHandler/subfolder/index.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+class HelloWorld
+{
+  public function sayHello(DateTimeImutable $date): void
+  {
+    echo 'Hello, ' . $date->format('j. n. Y');
+  }
+}

--- a/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit.coverage-fqn.xml
+++ b/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit.coverage-fqn.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="1234543251" phpunit="3.3.1">
+  <project name="AllTests" timestamp="1234543251">
+    <file name="/foo/bar/src/IndexControllerTest.php">
+      <class name="IndexControllerTest" namespace="global">
+        <metrics methods="5" coveredmethods="4" statements="7" coveredstatements="11" elements="12" coveredelements="15"/>
+      </class>
+      <line num="23" type="method" count="1"/>
+      <line num="24" type="stmt" count="1"/>
+      <line num="25" type="stmt" count="1"/>
+      <line num="26" type="stmt" count="1"/>
+      <line num="31" type="method" count="1"/>
+      <line num="32" type="stmt" count="1"/>
+      <line num="33" type="stmt" count="1"/>
+      <line num="38" type="method" count="1"/>
+      <line num="39" type="stmt" count="1"/>
+      <line num="40" type="stmt" count="1"/>
+      <line num="45" type="method" count="1"/>
+      <line num="46" type="stmt" count="1"/>
+      <line num="51" type="method" count="1"/>
+      <line num="52" type="stmt" count="1"/>
+      <line num="53" type="stmt" count="1"/>
+      <line num="54" type="stmt" count="1"/>
+      <line num="55" type="stmt" count="1"/>
+      <metrics loc="56" ncloc="28" classes="1" methods="5" coveredmethods="4" statements="12" coveredstatements="11" elements="17" coveredelements="15"/>
+    </file>
+    <file name="/foo/bar/src/Monkey.php">
+      <class name="Monkey" namespace="global" fullPackage="Animals.Monkey" category="Monkey" package="Animals">
+        <metrics methods="2" coveredmethods="0" statements="3" coveredstatements="0" elements="6" coveredelements="3"/>
+      </class>
+      <line num="34" type="method" count="1"/>
+      <line num="35" type="stmt" count="1"/>
+      <line num="38" type="stmt" count="1"/>
+      <line num="40" type="stmt" count="0"/>
+      <line num="45" type="method" count="1"/>
+      <line num="46" type="stmt" count="1"/>
+      <metrics loc="49" ncloc="20" classes="1" methods="2" coveredmethods="2" statements="4" coveredstatements="2" elements="6" coveredelements="3"/>
+    </file>
+    <file name="/foo/bar/src/Banana.php">
+      <class name="Banana" namespace="global" fullPackage="Fruits.Banana" category="Banana" package="Animals">
+        <metrics methods="2" coveredmethods="0" statements="3" coveredstatements="0" elements="5" coveredelements="0"/>
+      </class>
+      <line num="34" type="method" count="0"/>
+      <line num="35" type="stmt" count="0"/>
+      <line num="38" type="stmt" count="0"/>
+      <line num="40" type="stmt" count="0"/>
+      <line num="45" type="method" count="1"/>
+      <line num="46" type="stmt" count="1"/>
+      <metrics loc="49" ncloc="20" classes="1" methods="2" coveredmethods="0" statements="4" coveredstatements="0" elements="6" coveredelements="0"/>
+    </file>
+    <metrics files="34" loc="3147" ncloc="1621" classes="34" methods="94" coveredmethods="25" statements="100" coveredstatements="25" elements="100" coveredelements="25"/>
+  </project>
+</coverage>

--- a/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit.coverage-fqn_win.xml
+++ b/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit.coverage-fqn_win.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <coverage generated="1234543251" phpunit="3.3.1">
   <project name="AllTests" timestamp="1234543251">
-    <file name="\foo\bar\src\IndexControllerTest.php">
+    <file name="C:\foo\bar\src\IndexControllerTest.php">
       <class name="IndexControllerTest" namespace="global">
         <metrics methods="5" coveredmethods="4" statements="7" coveredstatements="11" elements="12" coveredelements="15"/>
       </class>
@@ -24,7 +24,7 @@
       <line num="55" type="stmt" count="1"/>
       <metrics loc="56" ncloc="28" classes="1" methods="5" coveredmethods="4" statements="12" coveredstatements="11" elements="17" coveredelements="15"/>
     </file>
-    <file name="\foo\bar\src\Monkey.php">
+    <file name="C:\foo\bar\src\Monkey.php">
       <class name="Monkey" namespace="global" fullPackage="Animals.Monkey" category="Monkey" package="Animals">
         <metrics methods="2" coveredmethods="0" statements="3" coveredstatements="0" elements="6" coveredelements="3"/>
       </class>
@@ -36,7 +36,7 @@
       <line num="46" type="stmt" count="1"/>
       <metrics loc="49" ncloc="20" classes="1" methods="2" coveredmethods="2" statements="4" coveredstatements="2" elements="6" coveredelements="3"/>
     </file>
-    <file name="\foo\bar\src\Banana.php">
+    <file name="C:\foo\bar\src\Banana.php">
       <class name="Banana" namespace="global" fullPackage="Fruits.Banana" category="Banana" package="Animals">
         <metrics methods="2" coveredmethods="0" statements="3" coveredstatements="0" elements="5" coveredelements="0"/>
       </class>

--- a/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit.coverage-fqn_win.xml
+++ b/sonar-php-plugin/src/test/resources/org/sonar/plugins/php/phpunit/sensor/phpunit.coverage-fqn_win.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coverage generated="1234543251" phpunit="3.3.1">
+  <project name="AllTests" timestamp="1234543251">
+    <file name="\foo\bar\src\IndexControllerTest.php">
+      <class name="IndexControllerTest" namespace="global">
+        <metrics methods="5" coveredmethods="4" statements="7" coveredstatements="11" elements="12" coveredelements="15"/>
+      </class>
+      <line num="23" type="method" count="1"/>
+      <line num="24" type="stmt" count="1"/>
+      <line num="25" type="stmt" count="1"/>
+      <line num="26" type="stmt" count="1"/>
+      <line num="31" type="method" count="1"/>
+      <line num="32" type="stmt" count="1"/>
+      <line num="33" type="stmt" count="1"/>
+      <line num="38" type="method" count="1"/>
+      <line num="39" type="stmt" count="1"/>
+      <line num="40" type="stmt" count="1"/>
+      <line num="45" type="method" count="1"/>
+      <line num="46" type="stmt" count="1"/>
+      <line num="51" type="method" count="1"/>
+      <line num="52" type="stmt" count="1"/>
+      <line num="53" type="stmt" count="1"/>
+      <line num="54" type="stmt" count="1"/>
+      <line num="55" type="stmt" count="1"/>
+      <metrics loc="56" ncloc="28" classes="1" methods="5" coveredmethods="4" statements="12" coveredstatements="11" elements="17" coveredelements="15"/>
+    </file>
+    <file name="\foo\bar\src\Monkey.php">
+      <class name="Monkey" namespace="global" fullPackage="Animals.Monkey" category="Monkey" package="Animals">
+        <metrics methods="2" coveredmethods="0" statements="3" coveredstatements="0" elements="6" coveredelements="3"/>
+      </class>
+      <line num="34" type="method" count="1"/>
+      <line num="35" type="stmt" count="1"/>
+      <line num="38" type="stmt" count="1"/>
+      <line num="40" type="stmt" count="0"/>
+      <line num="45" type="method" count="1"/>
+      <line num="46" type="stmt" count="1"/>
+      <metrics loc="49" ncloc="20" classes="1" methods="2" coveredmethods="2" statements="4" coveredstatements="2" elements="6" coveredelements="3"/>
+    </file>
+    <file name="\foo\bar\src\Banana.php">
+      <class name="Banana" namespace="global" fullPackage="Fruits.Banana" category="Banana" package="Animals">
+        <metrics methods="2" coveredmethods="0" statements="3" coveredstatements="0" elements="5" coveredelements="0"/>
+      </class>
+      <line num="34" type="method" count="0"/>
+      <line num="35" type="stmt" count="0"/>
+      <line num="38" type="stmt" count="0"/>
+      <line num="40" type="stmt" count="0"/>
+      <line num="45" type="method" count="1"/>
+      <line num="46" type="stmt" count="1"/>
+      <metrics loc="49" ncloc="20" classes="1" methods="2" coveredmethods="0" statements="4" coveredstatements="0" elements="6" coveredelements="0"/>
+    </file>
+    <metrics files="34" loc="3147" ncloc="1621" classes="34" methods="94" coveredmethods="25" statements="100" coveredstatements="25" elements="100" coveredelements="25"/>
+  </project>
+</coverage>


### PR DESCRIPTION
This PR changes many test resources, as they had to be adapted for the new logic. In the past, a hacky solution adjusted all paths before analyzing to an absolute path matching the test environment. The new implementation makes this hack unnecessary. The focus of this PR is on the new ExternalReportFileHandler, which makes the changes to the file paths as described in the ticket.
The missing coverage is not trivial to solve, because the tests for the coverage creation are done on a UNIX system. However, the test are properly executed in the Windows build step of the CI pipeline