### PR TITLE
SONARPHP-1366 Get rid of `SetUtils::immutableSetOf`

### DIFF
--- a/its/ruling/src/test/java/org/sonar/php/it/PhpPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/php/it/PhpPrAnalysisTest.java
@@ -69,8 +69,7 @@ public class PhpPrAnalysisTest {
       // <scenario>, <total files>, <skipped>, <deleted>
       Arguments.of("added", 3, 2, Collections.emptyList()),
       Arguments.of("changed", 2, 1, Collections.emptyList()),
-      Arguments.of("deleted", 1, 1, List.of("AbstractController.php"))
-    );
+      Arguments.of("deleted", 1, 1, List.of("AbstractController.php")));
   }
 
   @ParameterizedTest

--- a/php-checks/src/main/java/org/sonar/php/checks/AvoidDESCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/AvoidDESCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Locale;
 import java.util.Set;
 import org.sonar.check.Rule;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.LiteralTree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
@@ -34,7 +33,7 @@ public class AvoidDESCheck extends PHPVisitorCheck {
 
   private static final String MESSAGE = "Use the recommended AES (Advanced Encryption Standard) instead.";
 
-  private static final Set<String> MCRYPT_CIPHERS = SetUtils.immutableSetOf("MCRYPT_3DES", "MCRYPT_DES", "MCRYPT_DES_COMPAT",
+  private static final Set<String> MCRYPT_CIPHERS = Set.of("MCRYPT_3DES", "MCRYPT_DES", "MCRYPT_DES_COMPAT",
     "MCRYPT_TRIPLEDES");
   private static final String OPENSSL_DES = "des-ede3";
 

--- a/php-checks/src/main/java/org/sonar/php/checks/CallToIniSetCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/CallToIniSetCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 @Rule(key = CallToIniSetCheck.KEY)
@@ -33,7 +32,7 @@ public class CallToIniSetCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("ini_set");
+    return Set.of("ini_set");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/ClassCouplingCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/ClassCouplingCheck.java
@@ -29,7 +29,6 @@ import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.php.parser.LexicalConstant;
 import org.sonar.php.tree.impl.PHPTree;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
@@ -56,10 +55,10 @@ public class ClassCouplingCheck extends PHPVisitorCheck {
 
   public static final int DEFAULT = 20;
   private final Deque<Set<String>> types = new ArrayDeque<>();
-  private static final Set<String> DOC_TAGS = SetUtils.immutableSetOf(
+  private static final Set<String> DOC_TAGS = Set.of(
     "@var", "@global", "@staticvar", "@throws", "@param", "@return");
 
-  private static final Set<String> EXCLUDED_TYPES = SetUtils.immutableSetOf(
+  private static final Set<String> EXCLUDED_TYPES = Set.of(
     "integer", "int", "double", "float",
     "string", "array", "object", "boolean",
     "bool", "binary", "null", "mixed");

--- a/php-checks/src/main/java/org/sonar/php/checks/DeadStoreCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/DeadStoreCheck.java
@@ -31,7 +31,6 @@ import org.sonar.php.cfg.LiveVariablesAnalysis.LiveVariables;
 import org.sonar.php.cfg.LiveVariablesAnalysis.VariableUsage;
 import org.sonar.php.tree.symbols.Scope;
 import org.sonar.php.utils.collections.ListUtils;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.cfg.CfgBlock;
 import org.sonar.plugins.php.api.cfg.ControlFlowGraph;
 import org.sonar.plugins.php.api.symbols.Symbol;
@@ -47,7 +46,7 @@ import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
 @Rule(key = "S1854")
 public class DeadStoreCheck extends PHPSubscriptionCheck {
 
-  private static final Set<String> BASIC_LITERAL_VALUES = SetUtils.immutableSetOf(
+  private static final Set<String> BASIC_LITERAL_VALUES = Set.of(
     "true",
     "false",
     "1",

--- a/php-checks/src/main/java/org/sonar/php/checks/DirectlyAccessingSuperGlobalCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/DirectlyAccessingSuperGlobalCheck.java
@@ -21,7 +21,6 @@ package org.sonar.php.checks;
 
 import java.util.Set;
 import org.sonar.check.Rule;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.VariableIdentifierTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
 import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
@@ -32,7 +31,7 @@ public class DirectlyAccessingSuperGlobalCheck extends PHPVisitorCheck {
   private static final String MESSAGE = "Do not access \"%s\" directly.";
   public static final String KEY = "S2043";
 
-  private static final Set<String> SUPER_GLOBAL_REQUIRING_SANITIZATION = SetUtils.immutableSetOf(
+  private static final Set<String> SUPER_GLOBAL_REQUIRING_SANITIZATION = Set.of(
     "$_COOKIE", "$_ENV", "$_FILES", "$_GET", "$_POST", "$_REQUEST", "$_SERVER");
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/EchoWithParenthesisCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/EchoWithParenthesisCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
@@ -34,7 +33,7 @@ public class EchoWithParenthesisCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("echo");
+    return Set.of("echo");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/EvalUseCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/EvalUseCheck.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.api.PHPKeyword;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 @Rule(key = EvalUseCheck.KEY)
@@ -34,7 +33,7 @@ public class EvalUseCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf(PHPKeyword.EVAL.getValue());
+    return Set.of(PHPKeyword.EVAL.getValue());
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/FormattingStandardCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/FormattingStandardCheck.java
@@ -32,7 +32,6 @@ import org.sonar.php.checks.formatting.FunctionSpacingCheck;
 import org.sonar.php.checks.formatting.IndentationCheck;
 import org.sonar.php.checks.formatting.NamespaceAndUseStatementCheck;
 import org.sonar.php.checks.formatting.PunctuatorSpacingCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.ScriptTree;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.expression.ExpressionTree;
@@ -193,7 +192,7 @@ public class FormattingStandardCheck extends PHPVisitorCheck {
     type = "BOOLEAN")
   public boolean isExtendsAndImplementsLine = true;
 
-  private static final Set<String> INTERNAL_FUNCTIONS = SetUtils.immutableSetOf(
+  private static final Set<String> INTERNAL_FUNCTIONS = Set.of(
     PHPKeyword.ECHO.getValue(),
     PHPKeyword.ISSET.getValue(),
     PHPKeyword.EMPTY.getValue(),

--- a/php-checks/src/main/java/org/sonar/php/checks/FunctionNameCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/FunctionNameCheck.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.php.symbols.Symbols;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.declaration.FunctionDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
@@ -37,10 +36,10 @@ public class FunctionNameCheck extends PHPVisitorCheck {
 
   private static final String MESSAGE = "Rename function \"%s\" to match the regular expression %s.";
 
-  private static final Set<String> MAGIC_METHODS = SetUtils.immutableSetOf(
-    "__construct", "__destruct", "__call", "__callStatic", "__callStatic", "__get",
+  private static final Set<String> MAGIC_METHODS = Set.of(
+    "__construct", "__destruct", "__call", "__callStatic", "__get",
     "__set", "__isset", "__unset", "__sleep", "__wakeup", "__toString", "__invoke",
-    "__set_state", "__clone", "__clone", "__debugInfo");
+    "__set_state", "__clone", "__debugInfo");
   public static final String DEFAULT = "^[a-z][a-zA-Z0-9]*$";
   private Pattern pattern = null;
 

--- a/php-checks/src/main/java/org/sonar/php/checks/GenericExceptionCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/GenericExceptionCheck.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.ScriptTree;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -40,7 +39,7 @@ public class GenericExceptionCheck extends PHPVisitorCheck {
   public static final String KEY = "S112";
   public static final String MESSAGE = "Define and throw a dedicated exception instead of using a generic one.";
 
-  private static final Set<String> RAW_EXCEPTIONS = SetUtils.immutableSetOf("ErrorException", "RuntimeException", "Exception");
+  private static final Set<String> RAW_EXCEPTIONS = Set.of("ErrorException", "RuntimeException", "Exception");
   private Set<String> importedGenericExceptions = new HashSet<>();
   private boolean inGlobalNamespace = true;
 

--- a/php-checks/src/main/java/org/sonar/php/checks/IdenticalOperandsInBinaryExpressionCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/IdenticalOperandsInBinaryExpressionCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.SyntacticEquivalence;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.expression.BinaryExpressionTree;
 import org.sonar.plugins.php.api.tree.expression.LiteralTree;
@@ -35,7 +34,7 @@ public class IdenticalOperandsInBinaryExpressionCheck extends PHPVisitorCheck {
 
   private static final String MESSAGE = "Identical sub-expressions on both sides of operator \"%s\"";
 
-  private static final Set<String> EXCLUDED_OPERATORS = SetUtils.immutableSetOf("*", "+", ".");
+  private static final Set<String> EXCLUDED_OPERATORS = Set.of("*", "+", ".");
 
   @Override
   public void visitBinaryExpression(BinaryExpressionTree binaryExp) {

--- a/php-checks/src/main/java/org/sonar/php/checks/InsecureHashCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/InsecureHashCheck.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 import static org.sonar.php.checks.utils.CheckUtils.getFunctionName;
@@ -36,7 +35,7 @@ public class InsecureHashCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("md5", "sha1");
+    return Set.of("md5", "sha1");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/KeywordsAndConstantsNotLowerCaseCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/KeywordsAndConstantsNotLowerCaseCheck.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.php.api.PHPKeyword;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -44,7 +43,7 @@ public class KeywordsAndConstantsNotLowerCaseCheck extends PHPVisitorCheck {
   private static final String MESSAGE = "Write this \"%s\" %s in lower case.";
 
   private static final Pattern PATTERN = Pattern.compile("[a-z_]+");
-  private static final Set<String> KEYWORDS = SetUtils.immutableSetOf(PHPKeyword.getKeywordValues());
+  private static final Set<String> KEYWORDS = Set.of(PHPKeyword.getKeywordValues());
 
   @Override
   public void visitLiteral(LiteralTree tree) {

--- a/php-checks/src/main/java/org/sonar/php/checks/MissingMethodVisibilityCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/MissingMethodVisibilityCheck.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.php.api.PHPKeyword;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.ClassMemberTree;
@@ -40,7 +39,7 @@ public class MissingMethodVisibilityCheck extends PHPVisitorCheck {
   public static final String KEY = "S1784";
   private static final String MESSAGE = "Explicitly mention the visibility of this %s \"%s\".";
 
-  private static final Set<String> VISIBILITIES = SetUtils.immutableSetOf(
+  private static final Set<String> VISIBILITIES = Set.of(
     PHPKeyword.PRIVATE.getValue(),
     PHPKeyword.PROTECTED.getValue(),
     PHPKeyword.PUBLIC.getValue());

--- a/php-checks/src/main/java/org/sonar/php/checks/NoPaddingRsaCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/NoPaddingRsaCheck.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
@@ -42,7 +41,7 @@ public class NoPaddingRsaCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("openssl_public_encrypt");
+    return Set.of("openssl_public_encrypt");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/PHPDeprecatedFunctionUsageCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/PHPDeprecatedFunctionUsageCheck.java
@@ -103,20 +103,20 @@ public class PHPDeprecatedFunctionUsageCheck extends FunctionUsageCheck {
   private static final String PARSE_STR_FUNCTION = "parse_str";
   private static final String ASSERT_FUNCTION = "assert";
   private static final String DEFINE_FUNCTION = "define";
-  private static final Set<String> LOCALE_CATEGORY_CONSTANTS = SetUtils.immutableSetOf(
+  private static final Set<String> LOCALE_CATEGORY_CONSTANTS = Set.of(
     "LC_ALL", "LC_COLLATE", "LC_CTYPE", "LC_MONETARY", "LC_NUMERIC", "LC_TIME", "LC_MESSAGES");
 
-  private static final Set<String> DEPRECATED_CASE_SENSITIVE_CONSTANTS = SetUtils.immutableSetOf(
+  private static final Set<String> DEPRECATED_CASE_SENSITIVE_CONSTANTS = Set.of(
     "FILTER_FLAG_SCHEME_REQUIRED", "FILTER_FLAG_HOST_REQUIRED");
 
-  private static final Set<String> SEARCHING_STRING_FUNCTIONS = SetUtils.immutableSetOf(
+  private static final Set<String> SEARCHING_STRING_FUNCTIONS = Set.of(
     "stristr", "strrchr", "strstr", "strripos", "stripos", "strrpos", "strpos", "strchr");
 
   private static final Predicate<TreeValues> SPLFILEOBJECT_FGETSS = new ObjectMemberFunctionCall(FGETSS_FUNCTION, new NewObjectCall("SplFileObject"));
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    Set<String> functionNames = SetUtils.immutableSetOf(SET_LOCALE_FUNCTION, PARSE_STR_FUNCTION, ASSERT_FUNCTION, DEFINE_FUNCTION);
+    Set<String> functionNames = Set.of(SET_LOCALE_FUNCTION, PARSE_STR_FUNCTION, ASSERT_FUNCTION, DEFINE_FUNCTION);
     return SetUtils.concat(functionNames, NEW_BY_DEPRECATED_FUNCTIONS.keySet(), SEARCHING_STRING_FUNCTIONS);
   }
 

--- a/php-checks/src/main/java/org/sonar/php/checks/PhpSapiNameFunctionUsageCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/PhpSapiNameFunctionUsageCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 @Rule(key = PhpSapiNameFunctionUsageCheck.KEY)
@@ -33,7 +32,7 @@ public class PhpSapiNameFunctionUsageCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("php_sapi_name");
+    return Set.of("php_sapi_name");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/RandomGeneratorCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/RandomGeneratorCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 @Rule(key = "S2245")
@@ -32,7 +31,7 @@ public class RandomGeneratorCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("rand", "mt_rand");
+    return Set.of("rand", "mt_rand");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/RequireIncludeInstructionsUsageCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/RequireIncludeInstructionsUsageCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Locale;
 import java.util.Set;
 import org.sonar.check.Rule;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.CompilationUnitTree;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
@@ -33,8 +32,8 @@ public class RequireIncludeInstructionsUsageCheck extends PHPVisitorCheck {
   public static final String KEY = "S4833";
   private static final String MESSAGE = "Replace \"%s\" with namespace import mechanism through the \"use\" keyword.";
 
-  private static final Set<String> EXCLUDED_FILES = SetUtils.immutableSetOf("autoload.php", "ScriptHandler.php");
-  private static final Set<String> WRONG_FUNCTIONS = SetUtils.immutableSetOf(
+  private static final Set<String> EXCLUDED_FILES = Set.of("autoload.php", "ScriptHandler.php");
+  private static final Set<String> WRONG_FUNCTIONS = Set.of(
     "require",
     "include",
     "require_once",

--- a/php-checks/src/main/java/org/sonar/php/checks/SessionCookiePersistenceCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/SessionCookiePersistenceCheck.java
@@ -31,7 +31,6 @@ import org.sonar.php.ini.PhpIniCheck;
 import org.sonar.php.ini.PhpIniIssue;
 import org.sonar.php.ini.tree.Directive;
 import org.sonar.php.ini.tree.PhpIniFile;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.expression.ExpressionTree;
@@ -58,7 +57,7 @@ public class SessionCookiePersistenceCheck extends FunctionUsageCheck implements
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("session_set_cookie_params");
+    return Set.of("session_set_cookie_params");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/SleepFunctionUsageCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/SleepFunctionUsageCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 @Rule(key = SleepFunctionUsageCheck.KEY)
@@ -33,7 +32,7 @@ public class SleepFunctionUsageCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("sleep");
+    return Set.of("sleep");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/UnserializeCallCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/UnserializeCallCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 @Rule(key = UnserializeCallCheck.KEY)
@@ -33,7 +32,7 @@ public class UnserializeCallCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("unserialize");
+    return Set.of("unserialize");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/UseOfUninitializedVariableCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/UseOfUninitializedVariableCheck.java
@@ -457,7 +457,7 @@ public class UseOfUninitializedVariableCheck extends PHPVisitorCheck {
     @Override
     public void visitVariableIdentifier(VariableIdentifierTree tree) {
       if (uninitializedVariableDeclaration(tree)
-        && TreeUtils.findAncestorWithKind(tree, Set.of(Kind.STATIC_STATEMENT)) != null) {
+        && TreeUtils.findAncestorWithKind(tree, Kind.STATIC_STATEMENT) != null) {
         uninitializedStaticVariables.add(tree.variableExpression().text());
       }
       super.visitVariableIdentifier(tree);

--- a/php-checks/src/main/java/org/sonar/php/checks/UseOfUninitializedVariableCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/UseOfUninitializedVariableCheck.java
@@ -20,7 +20,6 @@
 package org.sonar.php.checks;
 
 import java.util.ArrayDeque;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.EnumMap;
@@ -36,7 +35,6 @@ import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.tree.TreeUtils;
 import org.sonar.php.tree.impl.PHPTree;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.cfg.CfgBlock;
 import org.sonar.plugins.php.api.cfg.CfgBranchingBlock;
 import org.sonar.plugins.php.api.cfg.ControlFlowGraph;
@@ -73,7 +71,7 @@ public class UseOfUninitializedVariableCheck extends PHPVisitorCheck {
     Kind.CATCH_BLOCK,
     Kind.ASSIGNMENT_BY_REFERENCE);
 
-  private static final Set<String> FUNCTION_CHANGING_CURRENT_SCOPE = new HashSet<>(Arrays.asList(
+  private static final Set<String> FUNCTION_CHANGING_CURRENT_SCOPE = Set.of(
     "eval",
     "extract",
     "parse_str",
@@ -82,10 +80,10 @@ public class UseOfUninitializedVariableCheck extends PHPVisitorCheck {
     "include",
     "include_once",
     "require",
-    "require_once"));
+    "require_once");
 
   // Note: "$argc" and "$argv" are not available in the function scope without using "global"
-  private static final Set<String> PREDEFINED_VARIABLES = new HashSet<>(Arrays.asList(
+  private static final Set<String> PREDEFINED_VARIABLES = Set.of(
     "$_COOKIE",
     "$_ENV",
     "$_FILES",
@@ -99,7 +97,7 @@ public class UseOfUninitializedVariableCheck extends PHPVisitorCheck {
     "$HTTP_RESPONSE_HEADER",
     "$PHP_ERRORMSG",
     // "$this" is defined only in method, but rule S2014 raises issues when it's used elsewhere
-    "$THIS"));
+    "$THIS");
 
   private static final Set<String> FUNCTION_ALLOWING_ARGUMENT_CHECK;
 
@@ -430,7 +428,8 @@ public class UseOfUninitializedVariableCheck extends PHPVisitorCheck {
 
     @Override
     public void visitFunctionCall(FunctionCallTree functionCall) {
-      if (FUNCTION_CHANGING_CURRENT_SCOPE.contains(CheckUtils.getLowerCaseFunctionName(functionCall))) {
+      String lowerCaseFunctionName = CheckUtils.getLowerCaseFunctionName(functionCall);
+      if (lowerCaseFunctionName != null && FUNCTION_CHANGING_CURRENT_SCOPE.contains(lowerCaseFunctionName)) {
         scopeWasChanged = true;
       }
       super.visitFunctionCall(functionCall);
@@ -458,7 +457,7 @@ public class UseOfUninitializedVariableCheck extends PHPVisitorCheck {
     @Override
     public void visitVariableIdentifier(VariableIdentifierTree tree) {
       if (uninitializedVariableDeclaration(tree)
-        && TreeUtils.findAncestorWithKind(tree, SetUtils.immutableSetOf(Kind.STATIC_STATEMENT)) != null) {
+        && TreeUtils.findAncestorWithKind(tree, Set.of(Kind.STATIC_STATEMENT)) != null) {
         uninitializedStaticVariables.add(tree.variableExpression().text());
       }
       super.visitVariableIdentifier(tree);

--- a/php-checks/src/main/java/org/sonar/php/checks/WrongAssignmentOperatorCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/WrongAssignmentOperatorCheck.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.php.tree.impl.expression.AssignmentExpressionTreeImpl;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.expression.AssignmentExpressionTree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
@@ -34,7 +33,7 @@ import org.sonar.plugins.php.api.visitors.PHPSubscriptionCheck;
 @Rule(key = "S2757")
 public class WrongAssignmentOperatorCheck extends PHPSubscriptionCheck {
 
-  private static final Set<String> SUSPICIOUS_TOKEN_VALUES = SetUtils.immutableSetOf("!", "+", "-");
+  private static final Set<String> SUSPICIOUS_TOKEN_VALUES = Set.of("!", "+", "-");
 
   @Override
   public List<Tree.Kind> nodesToVisit() {

--- a/php-checks/src/main/java/org/sonar/php/checks/phpini/PhpIniBoolean.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpini/PhpIniBoolean.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks.phpini;
 import java.util.Locale;
 import java.util.Set;
 import org.sonar.php.ini.tree.Directive;
-import org.sonar.php.utils.collections.SetUtils;
 
 public enum PhpIniBoolean {
 
@@ -32,7 +31,7 @@ public enum PhpIniBoolean {
   private final Set<String> variants;
 
   PhpIniBoolean(String... variants) {
-    this.variants = SetUtils.immutableSetOf(variants);
+    this.variants = Set.of(variants);
   }
 
   public boolean matchesValue(Directive directive) {

--- a/php-checks/src/main/java/org/sonar/php/checks/phpunit/AbortedTestCaseCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpunit/AbortedTestCaseCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks.phpunit;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.PhpUnitCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 import static org.sonar.php.checks.utils.CheckUtils.lowerCaseFunctionName;
@@ -31,7 +30,7 @@ import static org.sonar.php.checks.utils.CheckUtils.lowerCaseFunctionName;
 public class AbortedTestCaseCheck extends PhpUnitCheck {
 
   private static final String MESSAGE = "Either remove this call or add an explanation about why the test is aborted.";
-  private static final Set<String> ABORT_FUNCTIONS = SetUtils.immutableSetOf("marktestskipped", "marktestincomplete");
+  private static final Set<String> ABORT_FUNCTIONS = Set.of("marktestskipped", "marktestincomplete");
 
   @Override
   public void visitFunctionCall(FunctionCallTree fct) {
@@ -47,6 +46,7 @@ public class AbortedTestCaseCheck extends PhpUnitCheck {
   }
 
   private static boolean isAbortFunctionWithoutMessage(FunctionCallTree fct) {
-    return ABORT_FUNCTIONS.contains(lowerCaseFunctionName(fct)) && fct.callArguments().isEmpty();
+    String name = lowerCaseFunctionName(fct);
+    return name != null && ABORT_FUNCTIONS.contains(name) && fct.callArguments().isEmpty();
   }
 }

--- a/php-checks/src/main/java/org/sonar/php/checks/phpunit/AssertionInTryCatchCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpunit/AssertionInTryCatchCheck.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.PhpUnitCheck;
 import org.sonar.php.symbols.Symbols;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.declaration.NamespaceNameTree;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 import org.sonar.plugins.php.api.tree.expression.VariableIdentifierTree;
@@ -41,7 +40,7 @@ public class AssertionInTryCatchCheck extends PhpUnitCheck {
   private static final String MESSAGE = "Don't use this assertion inside a try-catch catching an assertion exception.";
   private static final String SECONDARY_MESSAGE = "Exception type that catches assertion exceptions.";
 
-  private static final Set<String> RELEVANT_EXCEPTIONS = SetUtils.immutableSetOf(
+  private static final Set<String> RELEVANT_EXCEPTIONS = Set.of(
     "exception",
     "phpunit\\framework\\expectationfailedexception",
     "phpunit\\framework\\assertionfailederror");

--- a/php-checks/src/main/java/org/sonar/php/checks/phpunit/AssertionsAfterExceptionCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpunit/AssertionsAfterExceptionCheck.java
@@ -27,7 +27,6 @@ import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.checks.utils.PhpUnitCheck;
 import org.sonar.php.tree.TreeUtils;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
@@ -39,12 +38,12 @@ public class AssertionsAfterExceptionCheck extends PhpUnitCheck {
   private static final String MESSAGE = "Don't perform an assertion here; An exception is expected to be raised before its execution.";
   private static final String MESSAGE_SINGLE = "Refactor this test; if this assertion's argument raises an exception, the assertion will never get executed.";
 
-  private static final Set<String> EXPECT_METHODS = SetUtils.immutableSetOf(
+  private static final Set<String> EXPECT_METHODS = Set.of(
     "expectexception",
     "expectexceptionmessage",
     "expectexceptionmessagematches",
     "exceptexceptioncode");
-  private static final Set<String> EXPECT_ANNOTATIONS = SetUtils.immutableSetOf(
+  private static final Set<String> EXPECT_ANNOTATIONS = Set.of(
     "expectedexception",
     "expectexceptionmessage",
     "expectedexceptionmessage",
@@ -92,7 +91,7 @@ public class AssertionsAfterExceptionCheck extends PhpUnitCheck {
     }
 
     String functionName = CheckUtils.lowerCaseFunctionName(tree);
-    if (EXPECT_METHODS.contains(functionName) && isMainStatementInBody(tree)) {
+    if (functionName != null && EXPECT_METHODS.contains(functionName) && isMainStatementInBody(tree)) {
       expectExceptionCall = tree;
     } else if (isAssertion(tree)) {
       assertionsStack.add(tree);

--- a/php-checks/src/main/java/org/sonar/php/checks/phpunit/BooleanOrNullLiteralInAssertionsCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpunit/BooleanOrNullLiteralInAssertionsCheck.java
@@ -28,7 +28,6 @@ import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.checks.utils.PhpUnitCheck;
 import org.sonar.php.tree.impl.expression.LiteralTreeImpl;
 import org.sonar.php.utils.collections.MapBuilder;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.expression.ExpressionTree;
@@ -38,13 +37,13 @@ import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 public class BooleanOrNullLiteralInAssertionsCheck extends PhpUnitCheck {
   private static final String MESSAGE = "Use %s instead.";
 
-  private static final Set<String> HANDLED_ASSERTIONS = SetUtils.immutableSetOf(
+  private static final Set<String> HANDLED_ASSERTIONS = Set.of(
     "assertEquals",
     "assertSame",
     "assertNotEquals",
     "assertNotSame");
 
-  private static final Set<String> INVERSE_ASSERTIONS = SetUtils.immutableSetOf("assertNotSame", "assertNotEquals");
+  private static final Set<String> INVERSE_ASSERTIONS = Set.of("assertNotSame", "assertNotEquals");
 
   private static final Map<String, String> REPLACEMENT_ASSERTIONS = MapBuilder.<String, String>builder()
     .put("true", "assertTrue()")

--- a/php-checks/src/main/java/org/sonar/php/checks/phpunit/NoAssertionInTestCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpunit/NoAssertionInTestCheck.java
@@ -24,13 +24,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.checks.utils.PhpUnitCheck;
 import org.sonar.php.tree.TreeUtils;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.symbols.Symbol;
 import org.sonar.plugins.php.api.symbols.SymbolTable;
 import org.sonar.plugins.php.api.tree.CompilationUnitTree;
@@ -146,8 +146,9 @@ public class NoAssertionInTestCheck extends PhpUnitCheck {
 
       Symbol symbol = symbolTable.getSymbol(((MemberAccessTree) callee).member());
       if (symbol != null && symbol.is(Symbol.Kind.FUNCTION)) {
-        return Optional.ofNullable((MethodDeclarationTree) TreeUtils.findAncestorWithKind(symbol.declaration(),
-          SetUtils.immutableSetOf(Tree.Kind.METHOD_DECLARATION)));
+        return Optional.ofNullable((MethodDeclarationTree) TreeUtils.findAncestorWithKind(
+          symbol.declaration(),
+          Set.of(Tree.Kind.METHOD_DECLARATION)));
       }
 
       return Optional.empty();

--- a/php-checks/src/main/java/org/sonar/php/checks/phpunit/NoAssertionInTestCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpunit/NoAssertionInTestCheck.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
@@ -148,7 +147,7 @@ public class NoAssertionInTestCheck extends PhpUnitCheck {
       if (symbol != null && symbol.is(Symbol.Kind.FUNCTION)) {
         return Optional.ofNullable((MethodDeclarationTree) TreeUtils.findAncestorWithKind(
           symbol.declaration(),
-          Set.of(Tree.Kind.METHOD_DECLARATION)));
+          Tree.Kind.METHOD_DECLARATION));
       }
 
       return Optional.empty();

--- a/php-checks/src/main/java/org/sonar/php/checks/phpunit/NotDiscoverableTestCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpunit/NotDiscoverableTestCheck.java
@@ -33,7 +33,6 @@ import org.sonar.php.checks.utils.PhpUnitCheck;
 import org.sonar.php.symbols.MethodSymbol;
 import org.sonar.php.symbols.Symbols;
 import org.sonar.php.tree.TreeUtils;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.ClassDeclarationTree;
 import org.sonar.plugins.php.api.tree.declaration.MethodDeclarationTree;
@@ -46,12 +45,12 @@ import org.sonar.plugins.php.api.visitors.PHPVisitorCheck;
 public class NotDiscoverableTestCheck extends PhpUnitCheck {
   private static final String MESSAGE_VISIBLE = "Adjust the visibility of this test method so that it can be executed by the test runner.";
   private static final String MESSAGE_MARKED = "Mark this method as a test so that it can be executed by the test runner.";
-  private static final Set<String> OVERRIDABLE_METHODS = SetUtils.immutableSetOf(
+  private static final Set<String> OVERRIDABLE_METHODS = Set.of(
     "setup",
     "teardown",
     "setupbeforeclass",
     "teardownafterclass");
-  private static final Set<String> SELF_OBJECTS = SetUtils.immutableSetOf("$this", "self", "static");
+  private static final Set<String> SELF_OBJECTS = Set.of("$this", "self", "static");
 
   private Map<String, Set<String>> internalCalledMethods = new HashMap<>();
   private Set<String> testMethods = new HashSet<>();

--- a/php-checks/src/main/java/org/sonar/php/checks/regex/AbstractRegexCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/regex/AbstractRegexCheck.java
@@ -32,7 +32,6 @@ import org.sonar.php.checks.utils.FunctionUsageCheck;
 import org.sonar.php.regex.PhpRegexCheck;
 import org.sonar.php.regex.PhpRegexUtils;
 import org.sonar.php.regex.RegexCheckContext;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.expression.ExpressionTree;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
@@ -57,7 +56,7 @@ public abstract class AbstractRegexCheck extends FunctionUsageCheck implements P
   public static final int PCRE_UTF8 = Pattern.UNICODE_CHARACTER_CLASS;
 
   protected static final Pattern DELIMITER_PATTERN = Pattern.compile("^[^a-zA-Z\\d\\r\\n\\t\\f\\v]");
-  protected static final Set<String> REGEX_FUNCTIONS = SetUtils.immutableSetOf(
+  protected static final Set<String> REGEX_FUNCTIONS = Set.of(
     "preg_replace", "preg_match", "preg_filter", "preg_replace_callback", "preg_split", "preg_match_all");
 
   private RegexCheckContext regexContext;

--- a/php-checks/src/main/java/org/sonar/php/checks/security/CommandLineArgumentCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/security/CommandLineArgumentCheck.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.tree.symbols.Scope;
 import org.sonar.php.tree.symbols.SymbolImpl;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.symbols.QualifiedName;
 import org.sonar.plugins.php.api.symbols.Symbol;
 import org.sonar.plugins.php.api.tree.CompilationUnitTree;
@@ -51,12 +50,12 @@ public class CommandLineArgumentCheck extends PHPVisitorCheck {
 
   private static final String MESSAGE = "Make sure that command line arguments are used safely here.";
 
-  private static final Set<QualifiedName> SUSPICIOUS_CLASS_INSTANTIATIONS = SetUtils.immutableSetOf(
+  private static final Set<QualifiedName> SUSPICIOUS_CLASS_INSTANTIATIONS = Set.of(
     qualifiedName("Zend\\Console\\Getopt"),
     qualifiedName("GetOpt\\Option"));
 
-  private static final Set<String> SUSPICIOUS_ARRAY_ACCESSES = SetUtils.immutableSetOf("$GLOBALS", "$_SERVER");
-  private static final Set<String> SUSPICIOUS_GLOBAL_IDENTIFIERS = SetUtils.immutableSetOf("$argv", "$HTTP_SERVER_VARS");
+  private static final Set<String> SUSPICIOUS_ARRAY_ACCESSES = Set.of("$GLOBALS", "$_SERVER");
+  private static final Set<String> SUSPICIOUS_GLOBAL_IDENTIFIERS = Set.of("$argv", "$HTTP_SERVER_VARS");
 
   private Map<Scope, List<String>> variableSetAsGlobalInScopes = new HashMap<>();
 

--- a/php-checks/src/main/java/org/sonar/php/checks/security/LDAPAuthenticatedConnectionCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/security/LDAPAuthenticatedConnectionCheck.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.expression.ExpressionTree;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
@@ -36,7 +35,7 @@ public class LDAPAuthenticatedConnectionCheck extends FunctionUsageCheck {
 
   @Override
   protected Set<String> lookedUpFunctionNames() {
-    return SetUtils.immutableSetOf("ldap_bind");
+    return Set.of("ldap_bind");
   }
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/security/LoggerConfigurationCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/security/LoggerConfigurationCheck.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.tree.impl.expression.PrefixExpressionTreeImpl;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.symbols.QualifiedName;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
@@ -53,7 +52,7 @@ public class LoggerConfigurationCheck extends PHPVisitorCheck {
 
   private static final String MESSAGE = "Make sure that this logger's configuration is safe.";
   private static final String ERROR_REPORTING = "error_reporting";
-  private static final Set<String> GLOBAL_CONFIGURATION_FUNCTIONS = SetUtils.immutableSetOf("ini_set", "ini_alter");
+  private static final Set<String> GLOBAL_CONFIGURATION_FUNCTIONS = Set.of("ini_set", "ini_alter");
   private static final Map<String, List<String>> WHITELISTED_VALUE_BY_DIRECTIVE = buildWhitelistedValues();
   private static final QualifiedName PSR_LOG_ABSTRACT_LOGGER_CLASS = qualifiedName("Psr\\Log\\AbstractLogger");
   private static final QualifiedName PSR_LOG_LOGGER_INTERFACE = qualifiedName("Psr\\Log\\LoggerInterface");

--- a/php-checks/src/main/java/org/sonar/php/checks/security/RegexUsageCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/security/RegexUsageCheck.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.CallArgumentTree;
 import org.sonar.plugins.php.api.tree.expression.ExpressionTree;
@@ -44,7 +43,7 @@ public class RegexUsageCheck extends FunctionUsageCheck {
   // this function accepts pattern as second argument, all others as first
   private static final String MB_EREG_SEARCH_INIT = "mb_ereg_search_init";
 
-  private static final Set<String> FUNCTION_NAMES = SetUtils.immutableSetOf(
+  private static final Set<String> FUNCTION_NAMES = Set.of(
     "ereg",
     "ereg_replace",
     "eregi",
@@ -79,7 +78,7 @@ public class RegexUsageCheck extends FunctionUsageCheck {
   protected void checkFunctionCall(FunctionCallTree tree) {
     int index = getPatternArgumentIndex(tree);
     Optional<CallArgumentTree> argument = CheckUtils.argument(tree, "pattern", index);
-    if (!argument.isPresent()) {
+    if (argument.isEmpty()) {
       return;
     }
 

--- a/php-checks/src/main/java/org/sonar/php/checks/security/RegexUsageCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/security/RegexUsageCheck.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.php.checks.security;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import org.sonar.check.Rule;
@@ -37,7 +35,7 @@ public class RegexUsageCheck extends FunctionUsageCheck {
 
   private static final String MESSAGE = "Make sure that using a regular expression is safe here.";
 
-  private static final Set<Character> SPECIAL_CHARS = new HashSet<>(Arrays.asList('+', '*', '{'));
+  private static final Set<Character> SPECIAL_CHARS = Set.of('+', '*', '{');
   private static final int MIN_PATTERN_LENGTH = 3 + 2 + 2; // 2 for string quotes and 2 for regex pattern delimeters
 
   // this function accepts pattern as second argument, all others as first

--- a/php-checks/src/main/java/org/sonar/php/checks/security/SignallingProcessCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/security/SignallingProcessCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks.security;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 @Rule(key = "S4828")
@@ -30,7 +29,7 @@ public class SignallingProcessCheck extends FunctionUsageCheck {
 
   private static final String MESSAGE = "Make sure that sending signals is safe here.";
 
-  private static final Set<String> FUNCTION_NAMES = SetUtils.immutableSetOf("posix_kill");
+  private static final Set<String> FUNCTION_NAMES = Set.of("posix_kill");
 
   @Override
   protected Set<String> lookedUpFunctionNames() {

--- a/php-checks/src/main/java/org/sonar/php/checks/security/SocketUsageCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/security/SocketUsageCheck.java
@@ -22,7 +22,6 @@ package org.sonar.php.checks.security;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.FunctionUsageCheck;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 @Rule(key = "S4818")
@@ -30,7 +29,7 @@ public class SocketUsageCheck extends FunctionUsageCheck {
 
   private static final String MESSAGE = "Make sure that sockets are used safely here.";
 
-  private static final Set<String> FUNCTION_NAMES = SetUtils.immutableSetOf(
+  private static final Set<String> FUNCTION_NAMES = Set.of(
     "socket_create",
     "socket_create_listen",
     "socket_addrinfo_bind",

--- a/php-checks/src/main/java/org/sonar/php/checks/wordpress/WordPressForceSslCheckPart.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/wordpress/WordPressForceSslCheckPart.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import org.sonar.php.checks.CheckBundle;
 import org.sonar.php.checks.CheckBundlePart;
 import org.sonar.php.checks.utils.CheckUtils;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
 public class WordPressForceSslCheckPart extends WordPressConfigVisitor implements CheckBundlePart {
@@ -33,7 +32,7 @@ public class WordPressForceSslCheckPart extends WordPressConfigVisitor implement
 
   @Override
   protected Set<String> configsToVisit() {
-    return SetUtils.immutableSetOf("FORCE_SSL_ADMIN", "FORCE_SSL_LOGIN");
+    return Set.of("FORCE_SSL_ADMIN", "FORCE_SSL_LOGIN");
   }
 
   @Override

--- a/php-frontend/src/main/java/org/sonar/php/tree/symbols/DeclarationVisitor.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/symbols/DeclarationVisitor.java
@@ -54,7 +54,6 @@ import org.sonar.php.symbols.Visibility;
 import org.sonar.php.tree.TreeUtils;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.php.tree.impl.declaration.MethodDeclarationTreeImpl;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.symbols.QualifiedName;
 import org.sonar.plugins.php.api.symbols.Symbol;
 import org.sonar.plugins.php.api.tree.CompilationUnitTree;
@@ -93,7 +92,7 @@ public class DeclarationVisitor extends NamespaceNameResolvingVisitor {
   private final Deque<ClassTree> classTreeStack = new ArrayDeque<>();
   private final Deque<FunctionSymbolProperties> functionPropertiesStack = new ArrayDeque<>();
 
-  private static final Set<String> VALID_VISIBILITIES = SetUtils.immutableSetOf("PUBLIC", "PRIVATE", "PROTECTED");
+  private static final Set<String> VALID_VISIBILITIES = Set.of("PUBLIC", "PRIVATE", "PROTECTED");
   private static final QualifiedName ANONYMOUS_CLASS_NAME = QualifiedName.qualifiedName("<anonymous_class>");
 
   DeclarationVisitor(SymbolTableImpl symbolTable, ProjectSymbolData projectSymbolData, @Nullable PhpFile file) {

--- a/php-frontend/src/main/java/org/sonar/php/tree/symbols/SymbolVisitor.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/symbols/SymbolVisitor.java
@@ -33,7 +33,6 @@ import org.sonar.php.api.PHPKeyword;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.php.tree.impl.VariableIdentifierTreeImpl;
 import org.sonar.php.utils.SourceBuilder;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.symbols.MemberSymbol;
 import org.sonar.plugins.php.api.symbols.QualifiedName;
 import org.sonar.plugins.php.api.symbols.Symbol;
@@ -81,7 +80,7 @@ import static java.util.Objects.requireNonNull;
 
 public class SymbolVisitor extends NamespaceNameResolvingVisitor {
 
-  private static final Set<String> BUILT_IN_VARIABLES = SetUtils.immutableSetOf(
+  private static final Set<String> BUILT_IN_VARIABLES = Set.of(
     "$this",
     "$GLOBALS",
     "$_SERVER",
@@ -95,7 +94,7 @@ public class SymbolVisitor extends NamespaceNameResolvingVisitor {
     "$http_response_header",
     "$_COOKIE",
     "$_REQUEST");
-  private static final Set<String> SELF_OBJECTS = SetUtils.immutableSetOf("$this", "self", "static");
+  private static final Set<String> SELF_OBJECTS = Set.of("$this", "self", "static");
 
   private final Deque<Scope> classScopes = new ArrayDeque<>();
   private final Map<Symbol, Scope> scopeBySymbol = new HashMap<>();

--- a/php-frontend/src/main/java/org/sonar/php/utils/collections/SetUtils.java
+++ b/php-frontend/src/main/java/org/sonar/php/utils/collections/SetUtils.java
@@ -19,25 +19,12 @@
  */
 package org.sonar.php.utils.collections;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * This class is used for Java < 9 to simplify the creation of sets.
- * After moving to Java > 9, should be replaced by Immutable Set Static Factory Methods
- * @see <a href="https://docs.oracle.com/javase/9/docs/api/java/util/Set.html#immutable">Immutable Set Static Factory Methods</a>
- */
 public class SetUtils {
 
   private SetUtils() {
-  }
-
-  @SafeVarargs
-  public static <T> Set<T> immutableSetOf(T... elements) {
-    Set<T> set = new HashSet<>(Arrays.asList(elements));
-    return Collections.unmodifiableSet(set);
   }
 
   @SafeVarargs

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/cfg/ControlFlowGraphBuilder.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/cfg/ControlFlowGraphBuilder.java
@@ -35,7 +35,6 @@ import org.sonar.api.utils.Preconditions;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.php.utils.LiteralUtils;
 import org.sonar.php.utils.collections.ListUtils;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.ScriptTree;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
@@ -226,7 +225,7 @@ class ControlFlowGraphBuilder {
 
   private PhpCfgBlock buildTryStatement(TryStatementTree tree, PhpCfgBlock successor) {
     PhpCfgBlock exitBlock = exitTargets.peek().exitBlock;
-    PhpCfgBlock finallyBlockEnd = createMultiSuccessorBlock(SetUtils.immutableSetOf(successor, exitBlock));
+    PhpCfgBlock finallyBlockEnd = createMultiSuccessorBlock(Set.of(successor, exitBlock));
     PhpCfgBlock finallyBlock;
     if (tree.finallyBlock() != null) {
       finallyBlock = build(tree.finallyBlock().statements(), finallyBlockEnd);
@@ -487,7 +486,7 @@ class ControlFlowGraphBuilder {
     @Override
     public Set<CfgBlock> successors() {
       Preconditions.checkState(successor != null, "No successor was set on %s", this);
-      return SetUtils.immutableSetOf(successor);
+      return Set.of(successor);
     }
 
     @Override

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/cfg/PhpCfgBlock.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/cfg/PhpCfgBlock.java
@@ -45,7 +45,6 @@ class PhpCfgBlock implements CfgBlock {
   }
 
   PhpCfgBlock(PhpCfgBlock successor, PhpCfgBlock syntacticSuccessor) {
-
     this(Set.of(successor), syntacticSuccessor);
   }
 

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/cfg/PhpCfgBlock.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/cfg/PhpCfgBlock.java
@@ -29,10 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.sonar.api.utils.Preconditions;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
-
-import static java.util.Objects.requireNonNull;
 
 class PhpCfgBlock implements CfgBlock {
 
@@ -49,8 +46,7 @@ class PhpCfgBlock implements CfgBlock {
 
   PhpCfgBlock(PhpCfgBlock successor, PhpCfgBlock syntacticSuccessor) {
 
-    this(SetUtils.immutableSetOf(successor), requireNonNull(syntacticSuccessor,
-      "Syntactic successor cannot be null"));
+    this(Set.of(successor), syntacticSuccessor);
   }
 
   PhpCfgBlock(Set<PhpCfgBlock> successors) {
@@ -58,7 +54,7 @@ class PhpCfgBlock implements CfgBlock {
   }
 
   PhpCfgBlock(PhpCfgBlock successor) {
-    this(SetUtils.immutableSetOf(successor));
+    this(Set.of(successor));
   }
 
   PhpCfgBlock() {

--- a/php-frontend/src/main/java/org/sonar/plugins/php/api/cfg/PhpCfgBranchingBlock.java
+++ b/php-frontend/src/main/java/org/sonar/plugins/php/api/cfg/PhpCfgBranchingBlock.java
@@ -19,9 +19,11 @@
  */
 package org.sonar.plugins.php.api.cfg;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.sonar.php.utils.collections.SetUtils;
 import org.sonar.plugins.php.api.tree.Tree;
 
 class PhpCfgBranchingBlock extends PhpCfgBlock implements CfgBranchingBlock {
@@ -54,7 +56,8 @@ class PhpCfgBranchingBlock extends PhpCfgBlock implements CfgBranchingBlock {
 
   @Override
   public Set<CfgBlock> successors() {
-    return SetUtils.immutableSetOf(trueSuccessor, falseSuccessor);
+    // `trueSuccessor` and `falseSuccessor` can be equal, but to comply with the API we need to have them in a Set
+    return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(trueSuccessor, falseSuccessor)));
   }
 
   @Override

--- a/php-frontend/src/test/java/org/sonar/php/utils/collections/SetUtilsTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/utils/collections/SetUtilsTest.java
@@ -25,34 +25,13 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class SetUtilsTest {
 
   @Test
-  void testReturnsUnmodifiableSet() {
-    Set<String> set = SetUtils.immutableSetOf();
-    assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> set.add("value"));
-  }
-
-  @Test
-  void testConstructStringsSet() {
-    Set<String> set = SetUtils.immutableSetOf("value1", "value2");
-
-    assertThat(set).containsExactlyInAnyOrder("value1", "value2");
-  }
-
-  @Test
-  void testConstructAnySet() {
-    Set<SomeType> set = SetUtils.immutableSetOf(new SomeType("value1"), new SomeType("value2"));
-
-    assertThat(set).containsExactlyInAnyOrder(new SomeType("value1"), new SomeType("value2"));
-  }
-
-  @Test
   void testConcatAnySet() {
-    Set<SomeType> set1 = SetUtils.immutableSetOf(new SomeType("value1"), new SomeType("value2"));
-    Set<SomeType> set2 = SetUtils.immutableSetOf(new SomeType("value3"), new SomeType("value4"));
+    Set<SomeType> set1 = Set.of(new SomeType("value1"), new SomeType("value2"));
+    Set<SomeType> set2 = Set.of(new SomeType("value3"), new SomeType("value4"));
 
     assertThat(SetUtils.concat(set1, set2))
       .containsExactlyInAnyOrder(new SomeType("value1"), new SomeType("value2"),
@@ -61,13 +40,13 @@ class SetUtilsTest {
 
   @Test
   void testConcatManySets() {
-    Set<SomeType> set1 = SetUtils.immutableSetOf(new SomeType("value1"), new SomeType("value2"));
-    Set<SomeType> set2 = SetUtils.immutableSetOf(new SomeType("value3"), new SomeType("value4"));
-    Set<SomeType> set3 = SetUtils.immutableSetOf(new SomeType("value5"), new SomeType("value6"));
-    Set<SomeType> set4 = SetUtils.immutableSetOf(new SomeType("value7"), new SomeType("value8"));
-    Set<SomeType> set5 = SetUtils.immutableSetOf(new SomeType("value9"), new SomeType("value10"));
-    Set<SomeType> set6 = SetUtils.immutableSetOf(new SomeType("value11"), new SomeType("value12"));
-    Set<SomeType> set7 = SetUtils.immutableSetOf(new SomeType("value13"), new SomeType("value14"));
+    Set<SomeType> set1 = Set.of(new SomeType("value1"), new SomeType("value2"));
+    Set<SomeType> set2 = Set.of(new SomeType("value3"), new SomeType("value4"));
+    Set<SomeType> set3 = Set.of(new SomeType("value5"), new SomeType("value6"));
+    Set<SomeType> set4 = Set.of(new SomeType("value7"), new SomeType("value8"));
+    Set<SomeType> set5 = Set.of(new SomeType("value9"), new SomeType("value10"));
+    Set<SomeType> set6 = Set.of(new SomeType("value11"), new SomeType("value12"));
+    Set<SomeType> set7 = Set.of(new SomeType("value13"), new SomeType("value14"));
 
     assertThat(SetUtils.concat(set1, set2, set3, set4, set5, set6, set7))
       .containsExactlyInAnyOrder(
@@ -82,8 +61,8 @@ class SetUtilsTest {
 
   @Test
   void testNoDifference() {
-    Set<String> set1 = SetUtils.immutableSetOf("A", "B", "C");
-    Set<String> set2 = SetUtils.immutableSetOf("A", "B", "C");
+    Set<String> set1 = Set.of("A", "B", "C");
+    Set<String> set2 = Set.of("A", "B", "C");
 
     assertThat(SetUtils.difference(set1, set2))
       .isEqualTo(Collections.emptySet());
@@ -91,8 +70,8 @@ class SetUtilsTest {
 
   @Test
   void testNoDifferenceOnLeft() {
-    Set<String> set1 = SetUtils.immutableSetOf("A", "B", "C");
-    Set<String> set2 = SetUtils.immutableSetOf("A", "B", "C", "D", "E");
+    Set<String> set1 = Set.of("A", "B", "C");
+    Set<String> set2 = Set.of("A", "B", "C", "D", "E");
 
     assertThat(SetUtils.difference(set1, set2))
       .isEqualTo(Collections.emptySet());
@@ -100,8 +79,8 @@ class SetUtilsTest {
 
   @Test
   void testDifference() {
-    Set<String> set1 = SetUtils.immutableSetOf("A", "B", "C");
-    Set<String> set2 = SetUtils.immutableSetOf("A", "B", "C", "D", "E");
+    Set<String> set1 = Set.of("A", "B", "C");
+    Set<String> set2 = Set.of("A", "B", "C", "D", "E");
 
     assertThat(SetUtils.difference(set2, set1))
       .containsExactlyInAnyOrder("D", "E");


### PR DESCRIPTION
Most of the usages created sets of constants. The only thing that needs to be checked for them is that `contains` is not called with potentially nullable parameters.
There are some places where a set is created from variables, then it also should be checked that it is not created from nulls