### PR TITLE
SONARPHP-1485 Get rid of plugin txt file for cache fingerprinting

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,11 +102,6 @@ build_task:
     #allow deployment of pull request artifacts to repox
     DEPLOY_PULL_REQUEST: true
     CIRRUS_CLONE_DEPTH: 50
-  sonar_cache:
-    folder: ${HOME}/.sonar/cache
-    fingerprint_script:
-      - echo ${CIRRUS_OS}
-      - curl --silent ${SONAR_HOST_URL}/deploy/plugins/index.txt | sort
   build_script:
     - git submodule update --init
     - source cirrus-env BUILD


### PR DESCRIPTION
We don't need to cache Sonar for the build task