### PR TITLE
Fix QA build on master due to changes in sonar scanner

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/it/php/Tests.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/php/Tests.java
@@ -194,6 +194,7 @@ class Tests {
       .filter(line -> !line.startsWith("WARN: SonarQube scanners will require Java 11+ starting on next version"))
       .filter(line -> !line.startsWith("WARN: The sonar.modules is a deprecated property and should not be used anymore"))
       .filter(line -> !line.startsWith("WARN: PHPUnit test cases are detected. Make sure to specify test sources via `sonar.test` to get more precise analysis results."))
+      .filter(line -> !line.startsWith("WARN: sonar.plugins.downloadOnlyRequired is false"))
       .filter(line -> !line.startsWith("WARNING: An illegal reflective access operation has occurred"))
       .filter(line -> !line.startsWith("WARNING: Illegal reflective access"))
       .filter(line -> !line.startsWith("WARNING: Please consider reporting this to the maintainers"))


### PR DESCRIPTION
The recent change in sonar scanner: https://github.com/SonarSource/sonarqube/blob/ef0a7e8dec055928331527b5d9598387873ab085/sonar-scanner-engine/src/main/java/org/sonar/scanner/bootstrap/ScannerPluginRepository.java#L73 introduced a new warning in logs when `sonar.plugins.downloadOnlyRequired` is set to `false`. This setting is needed for our integration tests. 
This PR fix qa build on master: https://cirrus-ci.com/task/6184200378777600