### PR TITLE
SONARPHP-1516 Avoid recompilation of Patterns

### DIFF
--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/lexical/InternalSyntaxToken.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/lexical/InternalSyntaxToken.java
@@ -22,6 +22,7 @@ package org.sonar.php.tree.impl.lexical;
 import com.sonar.sslr.api.TokenType;
 import java.util.Iterator;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.php.utils.collections.IteratorUtils;
 import org.sonar.plugins.php.api.tree.Tree;
@@ -30,6 +31,8 @@ import org.sonar.plugins.php.api.tree.lexical.SyntaxTrivia;
 import org.sonar.plugins.php.api.visitors.VisitorCheck;
 
 public class InternalSyntaxToken extends PHPTree implements SyntaxToken {
+
+  private static final Pattern LINEBREAK_PATTERN = Pattern.compile("\r\n|\n|\r");
 
   private final Kind kind;
 
@@ -54,7 +57,7 @@ public class InternalSyntaxToken extends PHPTree implements SyntaxToken {
   }
 
   private void calculateEndOffsets() {
-    String[] lines = value.split("\r\n|\n|\r", -1);
+    String[] lines = LINEBREAK_PATTERN.split(value, -1);
     endColumn = column + value.length();
     endLine = line + lines.length - 1;
 

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/lexical/InternalSyntaxTrivia.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/lexical/InternalSyntaxTrivia.java
@@ -22,6 +22,7 @@ package org.sonar.php.tree.impl.lexical;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
@@ -29,6 +30,8 @@ import org.sonar.plugins.php.api.tree.lexical.SyntaxTrivia;
 import org.sonar.plugins.php.api.visitors.VisitorCheck;
 
 public class InternalSyntaxTrivia extends PHPTree implements SyntaxTrivia {
+
+  private static final Pattern LINEBREAK_PATTERN = Pattern.compile("\r\n|\n|\r");
 
   private final String comment;
   private final int column;
@@ -44,7 +47,7 @@ public class InternalSyntaxTrivia extends PHPTree implements SyntaxTrivia {
   }
 
   private void calculateEndOffsets() {
-    String[] lines = comment.split("\r\n|\n|\r", -1);
+    String[] lines = LINEBREAK_PATTERN.split(comment, -1);
     endColumn = column + comment.length();
     endLine = startLine + lines.length - 1;
 

--- a/php-frontend/src/main/java/org/sonar/php/utils/SourceBuilder.java
+++ b/php-frontend/src/main/java/org/sonar/php/utils/SourceBuilder.java
@@ -21,6 +21,7 @@ package org.sonar.php.utils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
@@ -28,6 +29,8 @@ import org.sonar.plugins.php.api.tree.lexical.SyntaxTrivia;
 import org.sonar.plugins.php.api.visitors.PHPSubscriptionCheck;
 
 public class SourceBuilder extends PHPSubscriptionCheck {
+
+  private static final Pattern LINEBREAK_PATTERN = Pattern.compile("\r\n|\n|\r");
 
   private final StringBuilder stringBuilder = new StringBuilder();
   private int line = 1;
@@ -57,7 +60,7 @@ public class SourceBuilder extends PHPSubscriptionCheck {
     insertMissingSpaceBefore(token.line(), token.column());
     String text = token.text();
     stringBuilder.append(text);
-    String[] lines = text.split("\r\n|\n|\r", -1);
+    String[] lines = LINEBREAK_PATTERN.split(text, -1);
     if (lines.length > 1) {
       line += lines.length - 1;
       column = lines[lines.length - 1].length();


### PR DESCRIPTION
Hi,

this PR is avoiding Pattern recompilations in some "critical" paths. I've been profiling the scanner of a medium-large sized PHP project and this accounts for ~2% of the CPU frames

<img width="1068" alt="image" src="https://github.com/SonarSource/sonar-php/assets/6304496/a5f5101a-07e1-4534-815e-d70f5d0b2dfd">
<img width="1300" alt="image" src="https://github.com/SonarSource/sonar-php/assets/6304496/912339bd-a6ae-46e9-ae1a-c130dce5716d">

Alongside with some allocations obviously. I think the change is trivial enough and easily avoids some CPU cycles.

Let me know what you think. Since this is my first contribution to the project, please let me know what you need in order to have this PR merged.

Cheers,
Christoph