### PR TITLE
SONARPHP-1514 Skip trailing whitespace check for lines with very common last characters

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/TrailingWhitespaceCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/TrailingWhitespaceCheck.java
@@ -52,12 +52,21 @@ public class TrailingWhitespaceCheck extends PHPVisitorCheck {
   }
 
   private void checkLine(String line, int lineNumber) {
-    if (!line.isEmpty()) {
+    if (shouldCheckLine(line)) {
       Matcher m = WHITESPACE_PATTERN.matcher(line);
       if (m.find()) {
         context().newIssue(this, issueLocation(m, lineNumber));
       }
     }
+  }
+
+  private static boolean shouldCheckLine(String line) {
+    if (line.isEmpty()) {
+      return false;
+    }
+    // If the last character is a very common line-ending in PHP files, we can skip the check
+    char lastCharacter = line.charAt(line.length() - 1);
+    return lastCharacter != ';' && lastCharacter != '{' && lastCharacter != '}';
   }
 
   private static IssueLocation issueLocation(Matcher m, int lineNumber) {


### PR DESCRIPTION
Hi,

this PR optimizes the check for trailing whitespaces. I've been profiling the scanner of a medium-large sized PHP project and this accounts for ~4-5% of CPU frames due to a relatively costly regex check.

<img width="991" alt="image" src="https://github.com/user-attachments/assets/0419d5f5-781c-4d90-870c-92233db4e03b">

The idea of this PR is to skip the regex if the last character is a well known and common last character in PHP files. I've wrote a little script that groups the last characters in my project and the TOP 3 accounted for ~50%:
```
Count: 55774, Char: ';', Percentage: 29.68%
Count: 20205, Char: '{', Percentage: 10.75%
Count: 19524, Char: '}', Percentage: 10.39%
```
The PR could be extended to more characters, but I felt this was a good start while still being readable and not making too many assumptions about code-style of projects etc.

Let me know what you think.
Cheers,
Christoph