### PR TITLE
SONARPHP-1513 Use Charset directly in Scanner constructor

### DIFF
--- a/sonar-php-plugin/src/main/java/org/sonar/plugins/php/PhpExclusionsFileFilter.java
+++ b/sonar-php-plugin/src/main/java/org/sonar/plugins/php/PhpExclusionsFileFilter.java
@@ -106,7 +106,7 @@ public class PhpExclusionsFileFilter implements InputFileFilter {
 
     private static List<String> fileLines(InputFile inputFile) {
       List<String> lines = new ArrayList<>();
-      try (Scanner scanner = new Scanner(inputFile.inputStream(), inputFile.charset().name())) {
+      try (Scanner scanner = new Scanner(inputFile.inputStream(), inputFile.charset())) {
         while (scanner.hasNextLine()) {
           lines.add(scanner.nextLine());
         }


### PR DESCRIPTION
Hi,

since Java 10 `Scanner` can take a `Charset` parameter directly instead of passing the charset as a string and thus avoids getting the `Charset` yet again.

This is not really a hotspot or anything - just a drive-by find.

Cheers,
Christoph