### PR TITLE
SONARPHP-1580 Fix Cirrus cache key for Windows task

### DIFF
--- a/.cirrus/modules/qa.star
+++ b/.cirrus/modules/qa.star
@@ -48,7 +48,7 @@ def qa_os_win_task():
       "depends_on": "build",
       "ec2_instance": ec2_instance_builder(),
       "env": artifactory_reader_env(),
-      "gradle_cache": gradle_cache(),
+      "gradle_cache": gradle_cache(fingerprint_script="git rev-parse HEAD"),
       "gradle_wrapper_cache": gradle_wrapper_cache(),
       "build_script": qa_win_script(),
       "on_failure": on_failure(),


### PR DESCRIPTION
[SONARPHP-1580](https://sonarsource.atlassian.net/browse/SONARPHP-1580)

Caused by a change in cache instruction in cirrus-modules

[SONARPHP-1580]: https://sonarsource.atlassian.net/browse/SONARPHP-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ