### PR TITLE
SONARPHP-1586 Set SonarQube version back to DEV for qa tasks

### DIFF
--- a/.cirrus/modules/qa.star
+++ b/.cirrus/modules/qa.star
@@ -17,8 +17,7 @@ load(
 QA_PLUGIN_GRADLE_TASK = "its:plugin:integrationTest"
 QA_RULING_GRADLE_TASK = "its:ruling:integrationTest"
 QA_QUBE_LATEST_RELEASE = "LATEST_RELEASE"
-# Sonarqube versioning is changing, temporary pin for ITS
-QA_QUBE_DEV = "DEV[10.8]"
+QA_QUBE_DEV = "DEV"
 
 
 def on_failure():


### PR DESCRIPTION
[SONARPHP-1586](https://sonarsource.atlassian.net/browse/SONARPHP-1586)



[SONARPHP-1586]: https://sonarsource.atlassian.net/browse/SONARPHP-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ