### PR TITLE
SONARPHP-1530 S1125 should raise an issue when a boolean literal is used in a xor expression

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/BooleanEqualityComparisonCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/BooleanEqualityComparisonCheck.java
@@ -36,7 +36,8 @@ public class BooleanEqualityComparisonCheck extends PHPVisitorCheck {
     Kind.ALTERNATIVE_CONDITIONAL_AND,
     Kind.EQUAL_TO,
     Kind.NOT_EQUAL_TO,
-    Kind.ALTERNATIVE_NOT_EQUAL_TO
+    Kind.ALTERNATIVE_NOT_EQUAL_TO,
+    Kind.ALTERNATIVE_CONDITIONAL_XOR
   };
 
   @Override

--- a/php-checks/src/test/resources/checks/BooleanEqualityComparisonCheck.php
+++ b/php-checks/src/test/resources/checks/BooleanEqualityComparisonCheck.php
@@ -18,6 +18,8 @@ a || true         // Noncompliant
   || b
   || true;        // Noncompliant
 (a || true) ? b : c; // Noncompliant
+true xor a;       // Noncompliant
+$a xor false;     // Noncompliant
 
 a === false;      // OK - exception
 a === true;       // OK - exception


### PR DESCRIPTION
[SONARPHP-1530](https://sonarsource.atlassian.net/browse/SONARPHP-1530)

[SONARPHP-1530]: https://sonarsource.atlassian.net/browse/SONARPHP-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ