### PR TITLE
BUILD-7451 Update comment

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,5 +1,5 @@
 # Check Starlark specs: https://github.com/bazelbuild/starlark/blob/master/spec.md
-# DevInfra modules
+# Engineering Experience Squad modules
 load("github.com/SonarSource/cirrus-modules@v3", "load_features")
 # Modules
 load(


### PR DESCRIPTION
[BUILD-7451](https://sonarsource.atlassian.net/browse/BUILD-7451)

That way it use the name of the year attributed to DevInfra Team.

[BUILD-7451]: https://sonarsource.atlassian.net/browse/BUILD-7451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ