### PR TITLE
SONARPHP-1631 S6328: Do not raise on escape sequences that are using numbers

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/regex/GroupReplacementCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/regex/GroupReplacementCheck.java
@@ -35,7 +35,7 @@ public class GroupReplacementCheck extends AbstractRegexCheck {
 
   private static final String MESSAGE = "Referencing non-existing group%s: %s.";
   // Not allowing numbers starting by 0, other than zero itself.
-  private static final String NUMBER_PATTERN = "0(?!\\d)|[1-9]\\d*";
+  private static final String NUMBER_PATTERN = "0(?!\\d)|[1-9]\\d*+";
   private static final Pattern REFERENCE_PATTERN = Pattern.compile("\\$(" + NUMBER_PATTERN + ")|\\$\\{(" + NUMBER_PATTERN + ")}|\\\\(" + NUMBER_PATTERN + ")");
 
   @Override

--- a/php-checks/src/main/java/org/sonar/php/checks/regex/GroupReplacementCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/regex/GroupReplacementCheck.java
@@ -34,7 +34,9 @@ import org.sonarsource.analyzer.commons.regex.ast.RegexBaseVisitor;
 public class GroupReplacementCheck extends AbstractRegexCheck {
 
   private static final String MESSAGE = "Referencing non-existing group%s: %s.";
-  private static final Pattern REFERENCE_PATTERN = Pattern.compile("\\$(\\d+)|\\$\\{(\\d+)}|\\\\(\\d+)");
+  // Not allowing numbers starting by 0, other than zero itself.
+  private static final String NUMBER_PATTERN = "0(?!\\d)|[1-9]\\d*";
+  private static final Pattern REFERENCE_PATTERN = Pattern.compile("\\$(" + NUMBER_PATTERN + ")|\\$\\{(" + NUMBER_PATTERN + ")}|\\\\(" + NUMBER_PATTERN + ")");
 
   @Override
   protected Set<String> lookedUpFunctionNames() {

--- a/php-checks/src/test/resources/checks/regex/GroupReplacementCheck.php
+++ b/php-checks/src/test/resources/checks/regex/GroupReplacementCheck.php
@@ -21,8 +21,10 @@ class GroupReplacementCheck
     preg_replace("/(a)/", "$1", "");
     preg_replace("/(a)/", '${1}', "");
     preg_replace("/(a)/", "\1", "");
+    preg_replace("/(a)/", '\02', "");
     preg_replace("/(a)(b)/", "\1 \2", "");
     preg_replace("/(a(b))/", "\1 \2", "");
+    preg_replace('/(\"(\w+)\"\s?:)/im', "\"\033[36m$2\033[0m\":", $variable);
   }
 
   function unresolved_pattern() {


### PR DESCRIPTION
[SONARPHP-1631](https://sonarsource.atlassian.net/browse/SONARPHP-1631)



[SONARPHP-1631]: https://sonarsource.atlassian.net/browse/SONARPHP-1631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ