### PR TITLE
SONARPHP-1662 chore: Use renamed sonar.sca.exclusions property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,6 @@ sonar {
     property("sonar.links.ci", "https://cirrus-ci.com/github/SonarSource/sonar-php")
     property("sonar.links.scm", "https://github.com/SonarSource/sonar-php")
     property("sonar.links.issue", "https://jira.sonarsource.com/browse/SONARPHP")
-    property("sonar.sca.excludedManifests", "its/sources/**")
+    property("sonar.sca.exclusions", "its/sources/**")
   }
 }


### PR DESCRIPTION
[SONARPHP-1662](https://sonarsource.atlassian.net/browse/SONARPHP-1662)

`sonar.sca.excludedManifests` is deprecated in SQS 2025.3 and is replaced with `sonar.sca.exlusions`. The behavior is exactly the same, this is just a rename to better match other sonar properties.

[SONARPHP-1662]: https://sonarsource.atlassian.net/browse/SONARPHP-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ