### PR TITLE
SONARPHP-1672 Use "sonar.scanner.skipJreProvisioning" in integration tests

### DIFF
--- a/its/plugin/src/integrationTest/java/com/sonar/it/php/Tests.java
+++ b/its/plugin/src/integrationTest/java/com/sonar/it/php/Tests.java
@@ -79,6 +79,7 @@ class Tests {
 
   public static SonarScanner createScanner() {
     return SonarScanner.create()
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setScannerVersion(SCANNER_VERSION)
       .setProjectVersion("1.0")
       .setSourceDirs("src");

--- a/its/ruling/src/integrationTest/java/org/sonar/php/it/RulingHelper.java
+++ b/its/ruling/src/integrationTest/java/org/sonar/php/it/RulingHelper.java
@@ -63,6 +63,7 @@ public class RulingHelper {
 
   static SonarScanner prepareScanner(File path, String projectKey, String expectedIssueLocation, File litsDifferencesFile, String... keyValueProperties) {
     var sonarScanner = SonarScanner.create(path, keyValueProperties)
+      .setProperty("sonar.scanner.skipJreProvisioning", "true")
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1")


### PR DESCRIPTION
[SONARPHP-1672](https://sonarsource.atlassian.net/browse/SONARPHP-1672)

On ephemeral CI machine this avoids unnecessary downloading and unpacking of JRE from SQ and thus reduces time of execution of the first project analysis in integration tests.

During execution of integration tests we already have suitable JDK.

Testing of JRE provisioning feature should not be the responsibility of analyzers.

[SONARPHP-1672]: https://sonarsource.atlassian.net/browse/SONARPHP-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ