### PR TITLE
SONARPHP-1691 Configure Renovate to pin digests of third-party GHAs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,9 +23,23 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchPackageNames": [
+        "SonarSource/*"
+      ],
       "pinDigests": false,
-      "groupName": "all github actions",
-      "groupSlug": "all-github-actions"
+      "groupName": "all Sonar GitHub Actions",
+      "groupSlug": "all-sonar-github-actions"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "!SonarSource/*"
+      ],
+      "pinDigests": true,
+      "groupName": "all third-party GitHub Actions",
+      "groupSlug": "all-3rd-party-github-actions"
     },
     {
       "matchManagers": [


### PR DESCRIPTION
[SONARPHP-1691](https://sonarsource.atlassian.net/browse/SONARPHP-1691)

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[SONARPHP-1691]: https://sonarsource.atlassian.net/browse/SONARPHP-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ