### PR TITLE
SONARPHP-1717 Improve code coverage for SymbolQualifiedNameTest

### DIFF
--- a/php-frontend/src/test/java/org/sonar/php/tree/symbols/SymbolQualifiedNameTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/symbols/SymbolQualifiedNameTest.java
@@ -48,7 +48,7 @@ class SymbolQualifiedNameTest {
   @Test
   void shouldThrowExceptionForEmptyNamespace() {
     var qualifiedName = SymbolQualifiedName.create("A", "B", "C");
-    var token = new InternalSyntaxToken(1,2,"my_name", List.of(), 0, false);
+    var token = new InternalSyntaxToken(1, 2, "my_name", List.of(), 0, false);
     var nameIdTree = new NameIdentifierTreeImpl(token);
     var namespaces = new SeparatedListImpl<NameIdentifierTree>(List.of(), List.of());
     var namespaceNameTree = new NamespaceNameTreeImpl(null, namespaces, nameIdTree);
@@ -56,7 +56,7 @@ class SymbolQualifiedNameTest {
       .isInstanceOf(IllegalStateException.class)
       .withMessage("Unable to resolve my_name which has only aliased name");
   }
-  
+
   @Test
   void shouldReturnFalseForEqualsForDifferentTypes() {
     var qualifiedName = SymbolQualifiedName.create("A", "B", "C");

--- a/php-frontend/src/test/java/org/sonar/php/tree/symbols/SymbolQualifiedNameTest.java
+++ b/php-frontend/src/test/java/org/sonar/php/tree/symbols/SymbolQualifiedNameTest.java
@@ -16,17 +16,59 @@
  */
 package org.sonar.php.tree.symbols;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.sonar.php.tree.impl.SeparatedListImpl;
+import org.sonar.php.tree.impl.declaration.NamespaceNameTreeImpl;
+import org.sonar.php.tree.impl.expression.NameIdentifierTreeImpl;
+import org.sonar.php.tree.impl.lexical.InternalSyntaxToken;
+import org.sonar.plugins.php.api.tree.expression.NameIdentifierTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 
 class SymbolQualifiedNameTest {
 
   @Test
-  void test() {
-    SymbolQualifiedName qualifiedName1 = SymbolQualifiedName.create("A", "B", "C");
-    SymbolQualifiedName qualifiedName2 = SymbolQualifiedName.create("a", "b", "c");
-    assertThat(qualifiedName1).hasToString("a\\b\\c").isEqualTo(qualifiedName2);
+  void shouldVerifyToStringAndEquals() {
+    var qualifiedName1 = SymbolQualifiedName.create("A", "B", "C");
+    var qualifiedName2 = SymbolQualifiedName.create("a", "b", "c");
+    assertThat(qualifiedName1)
+      .hasToString("a\\b\\c")
+      .isEqualTo(qualifiedName2);
   }
 
+  @Test
+  void shouldThrowExceptionForCreateAndZeroArguments() {
+    assertThatException().isThrownBy(SymbolQualifiedName::create)
+      .isInstanceOf(IllegalStateException.class)
+      .withMessage("Cannot create an empty qualified name");
+  }
+
+  @Test
+  void shouldThrowExceptionForEmptyNamespace() {
+    var qualifiedName = SymbolQualifiedName.create("A", "B", "C");
+    var token = new InternalSyntaxToken(1,2,"my_name", List.of(), 0, false);
+    var nameIdTree = new NameIdentifierTreeImpl(token);
+    var namespaces = new SeparatedListImpl<NameIdentifierTree>(List.of(), List.of());
+    var namespaceNameTree = new NamespaceNameTreeImpl(null, namespaces, nameIdTree);
+    assertThatException().isThrownBy(() -> qualifiedName.resolveAliasedName(namespaceNameTree))
+      .isInstanceOf(IllegalStateException.class)
+      .withMessage("Unable to resolve my_name which has only aliased name");
+  }
+  
+  @Test
+  void shouldReturnFalseForEqualsForDifferentTypes() {
+    var qualifiedName = SymbolQualifiedName.create("A", "B", "C");
+    var memberQualifiedName = new MemberQualifiedName(null, "my_name", null);
+    var actual = qualifiedName.equals(memberQualifiedName);
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  void shouldReturnTruForEqualsWhenCompareToItself() {
+    var qualifiedName = SymbolQualifiedName.create("A", "B", "C");
+    var actual = qualifiedName.equals(qualifiedName);
+    assertThat(actual).isTrue();
+  }
 }


### PR DESCRIPTION
[SONARPHP-1717](https://sonarsource.atlassian.net/browse/SONARPHP-1717)

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[SONARPHP-1717]: https://sonarsource.atlassian.net/browse/SONARPHP-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ