### PR TITLE
Fix releasability status check

### DIFF
--- a/.github/workflows/releasability-status.yaml
+++ b/.github/workflows/releasability-status.yaml
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: SonarSource/gh-action_releasability/releasability-status@v3
         with:
-          optional_checks: 'jira'
+          optional_checks: 'Jira'
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Example failure on current master: https://github.com/SonarSource/sonar-php/actions/runs/24441750071

I think it is because of this. 