### PR TITLE
SONARPHP-1814 Bot PRs should also create Jira tickets

### DIFF
--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -13,7 +13,6 @@ jobs:
     # For external PR, ticket should be created manually
     if: |
         github.event.pull_request.head.repo.full_name == github.repository
-        && github.event.sender.type != 'Bot'
     steps:
       - id: secrets
         uses: SonarSource/vault-action-wrapper@v3


### PR DESCRIPTION
This pull request makes a small change to the workflow configuration by removing a condition that excluded bot users from running certain steps. Now, the workflow will also run for pull requests created by bots.

* Removed the check for `github.event.sender.type != 'Bot'`, allowing workflow steps to run for bot-created pull requests in `.github/workflows/PullRequestCreated.yml`.