### PR TITLE
SONARPHP-1846 Disable slack notification on rule metadata update

### DIFF
--- a/.github/workflows/update-rule-metadata.yml
+++ b/.github/workflows/update-rule-metadata.yml
@@ -35,4 +35,3 @@ jobs:
           rule-api-version: ${{ github.event.inputs.rule-api-version}}
           branch: ${{ github.event.inputs.branch }}
           rspec-branch: ${{ github.event.inputs.rspec-branch }}
-          slack-channel: squad-security-taint-notifs


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
  - Removed the Slack notification step from the `update-rule-metadata.yml` workflow to prevent alerts on metadata updates.

<sub>This will update automatically on new commits.</sub>