### PR TITLE
SONARPHP-1840 S4790: suppress when hash output is truncated by substr/mb_substr

### DIFF
--- a/its/ruling/src/integrationTest/resources/expected/PHPWord/php-S4790.json
+++ b/its/ruling/src/integrationTest/resources/expected/PHPWord/php-S4790.json
@@ -1,7 +1,4 @@
 {
-"PHPWord:src/PhpWord/Element/AbstractElement.php": [
-259
-],
 "PHPWord:src/PhpWord/Element/Image.php": [
 216
 ],
@@ -10,9 +7,6 @@
 ],
 "PHPWord:src/PhpWord/Writer/Word2007/Element/OLEObject.php": [
 42
-],
-"PHPWord:src/PhpWord/Writer/Word2007/Part/Numbering.php": [
-193
 ],
 "PHPWord:tests/PhpWordTests/Element/ImageTest.php": [
 39,

--- a/its/ruling/src/integrationTest/resources/expected/PHP_CodeSniffer/php-S4790.json
+++ b/its/ruling/src/integrationTest/resources/expected/PHP_CodeSniffer/php-S4790.json
@@ -2,8 +2,6 @@
 "PHP_CodeSniffer:src/Util/Cache.php": [
 144,
 149,
-150,
-164,
-235
+150
 ]
 }

--- a/php-checks/src/main/java/org/sonar/php/checks/security/CryptographicHashCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/security/CryptographicHashCheck.java
@@ -21,6 +21,7 @@ import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
 import org.sonar.php.checks.utils.argumentmatching.ArgumentVerifierValueContainment;
 import org.sonar.php.checks.utils.argumentmatching.FunctionArgumentCheck;
+import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.expression.ExpressionTree;
 import org.sonar.plugins.php.api.tree.expression.FunctionCallTree;
 
@@ -30,6 +31,7 @@ public class CryptographicHashCheck extends FunctionArgumentCheck {
   private static final String MESSAGE = "Make sure this weak hash algorithm is not used in a sensitive context here.";
 
   private static final Set<String> WEAK_HASH_FUNCTIONS = Set.of("md5", "sha1");
+  private static final Set<String> SUBSTR_FUNCTIONS = Set.of("substr", "mb_substr");
   private static final Set<String> WEAK_HASH_ARGUMENTS = Set.of(
     "md2",
     "md4",
@@ -71,14 +73,37 @@ public class CryptographicHashCheck extends FunctionArgumentCheck {
 
     String functionName = CheckUtils.getLowerCaseFunctionName(tree);
     if (functionName != null && WEAK_HASH_FUNCTIONS.contains(functionName)) {
-      createIssue(tree);
+      if (!isWrappedInSubstr(tree)) {
+        createIssue(tree);
+      }
       return;
     }
 
     checkArgument(tree, "hash_init", hashArgumentVerifier);
-    checkArgument(tree, "hash", hashArgumentVerifier);
+    if (!isWrappedInSubstr(tree)) {
+      checkArgument(tree, "hash", hashArgumentVerifier);
+    }
     checkArgument(tree, "hash_pbkdf2", hashArgumentVerifier);
     checkArgument(tree, "mhash", mHashArgumentVerifier);
+  }
+
+  // SONARPHP-1840: Suppress when the hash output is immediately truncated by substr/mb_substr,
+  // which signals a non-cryptographic use (cache key, ETag, short identifier, etc.)
+  private static boolean isWrappedInSubstr(FunctionCallTree hashCall) {
+    Tree parent = hashCall.getParent();
+    if (parent == null || !parent.is(Tree.Kind.CALL_ARGUMENT)) {
+      return false;
+    }
+    Tree grandParent = parent.getParent();
+    if (grandParent == null || !grandParent.is(Tree.Kind.FUNCTION_CALL)) {
+      return false;
+    }
+    FunctionCallTree outerCall = (FunctionCallTree) grandParent;
+    String outerName = CheckUtils.getLowerCaseFunctionName(outerCall);
+    if (outerName == null || !SUBSTR_FUNCTIONS.contains(outerName)) {
+      return false;
+    }
+    return !outerCall.callArguments().isEmpty() && outerCall.callArguments().get(0) == parent;
   }
 
   protected void createIssue(FunctionCallTree tree) {

--- a/php-checks/src/test/resources/checks/security/CryptographicHashCheck.php
+++ b/php-checks/src/test/resources/checks/security/CryptographicHashCheck.php
@@ -75,3 +75,27 @@ mhash($data, hash: MHASH_HAVAL224); // Noncompliant
 mhash(MHASH_SHA512, $data); // Compliant
 mhash("xyz", $data); // Compliant
 mhash(algo: "xyz", $data); // Compliant
+
+// Compliant: truncated output signals a non-cryptographic use (cache key, ETag, short identifier, etc.)
+substr(md5($data), 0, 8);
+substr(sha1($url), 0, 4);
+substr(hash('sha1', $email), 0, 5);
+substr(hash('sha1', $seed), -6);
+mb_substr(md5($data), 0, 8);
+mb_substr(sha1($data), 0, 4);
+SUBSTR(md5($data), 0, 8);
+
+// Hash used as length argument rather than string to truncate - still noncompliant
+substr($str, 0, md5($str));  // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+//              ^^^
+substr($str, 0, sha1($str)); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+substr($str, 0, hash('sha1', $str)); // Noncompliant
+//                   ^^^^^^
+
+// Wrapped in something other than substr/mb_substr - still noncompliant
+strtolower(md5($data)); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+//         ^^^
+strtolower(sha1($data)); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}
+
+// Dynamic/variable callee - still noncompliant, no NPE on null function name
+$fn(md5($data)); // Noncompliant {{Make sure this weak hash algorithm is not used in a sensitive context here.}}


### PR DESCRIPTION
## Summary

- Adds `isWrappedInSubstr` helper to `CryptographicHashCheck` that detects when a weak-hash call is the first argument of `substr`/`mb_substr`
- Suppresses the S4790 hotspot for `md5()`, `sha1()`, and `hash(weak_algo, ...)` in this context, since truncated output cannot fulfill any cryptographic guarantee (password storage, signing, MAC, integrity)
- `hash_init`, `hash_pbkdf2`, and `mhash` are intentionally unaffected

## Test plan

- [x] Compliant cases: `substr(md5(...), 0, 8)`, `mb_substr(sha1(...), 0, 4)`, negative offset (`-6`), `hash('sha1', ...)` as first arg, case-insensitive `SUBSTR`
- [x] Still noncompliant: hash used as the length argument (position 2), hash wrapped in `strtolower` or other non-substr functions
- [x] `CryptographicHashCheckTest` passes
- [x] Spotless check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)