### PR TITLE
SONARPHP-1853 Link integration tickets to KTLO epic in SONARSEC

### DIFF
--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -79,3 +79,4 @@ jobs:
       runner-environment: sonar-xs
       verbose: ${{ inputs.verbose }}
       bump-version: true
+      ktlo-jira-project-key: "SONARSEC"


### PR DESCRIPTION
Fixes https://sonarsource.atlassian.net/browse/SONARPHP-1853

Add `ktlo-jira-project-key: "SONARSEC"` so integration tickets created during releases are linked to the KTLO epic in the SONARSEC project. Without this the shared workflow defaults to searching in SONARPHP (which has no KTLO epic) and linking silently fails.

Same fix as sonar-abap [#356](https://github.com/SonarSource/sonar-abap/pull/356), sonar-rpg [#410](https://github.com/SonarSource/sonar-rpg/pull/410), and sonar-pli [#326](https://github.com/SonarSource/sonar-pli/pull/326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Workflow Configuration:**
  - Added `ktlo-jira-project-key: "SONARSEC"` to link integration tickets to the correct KTLO epic.
  - Enabled `use-jira-sandbox`, `is-draft-release`, and `sqc-plugins-deployer-integration` flags in `AutomateRelease.yml`.

<sub>This will update automatically on new commits.</sub>