### PR TITLE
SONARPHP-1855 ToggleLockBranch: Add additional-message

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -13,7 +13,6 @@ on:
         description: "Branch to to toggle lock on"
         required: true
         default: "master"
-    inputs:
       additional-message:
         description: 'Additional Slack message text'
         required: false

--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -13,6 +13,10 @@ on:
         description: "Branch to to toggle lock on"
         required: true
         default: "master"
+    inputs:
+      additional-message:
+        description: 'Additional Slack message text'
+        required: false
 
 jobs:
   ToggleLockBranch_job:
@@ -31,5 +35,6 @@ jobs:
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
+          additional-message: ${{ github.event.inputs.additional-message }}
           slack-channel: squad-security-taint-notifs
           branch-pattern: ${{ inputs.branch }}


### PR DESCRIPTION
This new parameter will be appended to the Slack message. It removes the need to go to Slack and explain why it's being locked