### PR TITLE
SONARPHP-1865 Disable slack notification on master freeze during release action

### DIFF
--- a/.github/workflows/AutomateRelease.yml
+++ b/.github/workflows/AutomateRelease.yml
@@ -76,6 +76,7 @@ jobs:
       create-sli-ticket: true
       create-sle-ticket: true
       slack-channel: "squad-security-taint-notifs"
+      freeze-branch-slack-notification: false
       runner-environment: sonar-xs
       verbose: ${{ inputs.verbose }}
       bump-version: true


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
  - Set `freeze-branch-slack-notification` to `false` in `.github/workflows/AutomateRelease.yml` to disable notifications during master freeze.

<sub>This will update automatically on new commits.</sub>