### PR TITLE
SONARPHP-1866 php:S1448 entity class exclusion does not recognize PHPDoc @Entity annotation, only PHP 8 native attributes

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/TooManyMethodsInClassCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/TooManyMethodsInClassCheck.java
@@ -16,11 +16,12 @@
  */
 package org.sonar.php.checks;
 
-import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.php.api.PHPKeyword;
+import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.php.tree.symbols.HasMethodSymbol;
 import org.sonar.plugins.php.api.tree.Tree.Kind;
 import org.sonar.plugins.php.api.tree.declaration.AttributeGroupTree;
@@ -42,6 +43,7 @@ public class TooManyMethodsInClassCheck extends PHPVisitorCheck {
 
   private static final int DEFAULT_THRESHOLD = 20;
   private static final boolean DEFAULT_NON_PUBLIC = true;
+  private static final Pattern ENTITY_PHPDOC_PATTERN = Pattern.compile("@(ORM\\\\)?Entity\\b");
 
   @RuleProperty(
     key = "maximumMethodThreshold",
@@ -111,19 +113,16 @@ public class TooManyMethodsInClassCheck extends PHPVisitorCheck {
   }
 
   private static boolean classHasEntityAttribute(ClassTree tree) {
-    List<AttributeGroupTree> attributes = tree.attributeGroups();
-
-    if (!attributes.isEmpty()) {
-      for (AttributeGroupTree attribute : attributes) {
-        for (AttributeTree attributeTree : attribute.attributes()) {
-          String finalName = attributeTree.name().fullyQualifiedName();
-          if ("ORM\\Entity".equals(finalName) || "Entity".equals(finalName)) {
-            return true;
-          }
+    for (AttributeGroupTree attribute : tree.attributeGroups()) {
+      for (AttributeTree attributeTree : attribute.attributes()) {
+        String finalName = attributeTree.name().fullyQualifiedName();
+        if ("ORM\\Entity".equals(finalName) || "Entity".equals(finalName)) {
+          return true;
         }
       }
     }
-    return false;
+    return ((PHPTree) tree).getFirstToken().trivias().stream()
+      .anyMatch(trivia -> ENTITY_PHPDOC_PATTERN.matcher(trivia.text()).find());
   }
 
   /**

--- a/php-checks/src/test/resources/checks/TooManyMethodsInClassCheck.php
+++ b/php-checks/src/test/resources/checks/TooManyMethodsInClassCheck.php
@@ -114,3 +114,48 @@ class ClassDB {         // OK
 
       public function f4() {  }
   }
+
+  /**
+   * @Entity
+   */
+  class PhpDocEntityClass { // OK
+
+      public function f1() {  }
+
+      public function f2() {  }
+
+      public function f3() {  }
+
+      public function f4() {  }
+  }
+
+  /**
+   * @ORM\Entity(repositoryClass="MyClassRepository")
+   * @Table(name="my_class")
+   */
+  class PhpDocOrmEntityClass { // OK
+
+      public function f1() {  }
+
+      public function f2() {  }
+
+      public function f3() {  }
+
+      public function f4() {  }
+  }
+
+  /**
+   * @author Someone
+   * @Entity(repositoryClass="X\Y\Z\MyClassRepository")
+   * @HasLifecycleCallbacks
+   */
+  abstract class AbstractPhpDocEntityClass { // OK
+
+      public function f1() {  }
+
+      public function f2() {  }
+
+      public function f3() {  }
+
+      public function f4() {  }
+  }


### PR DESCRIPTION
## Summary

- `php:S1448` has an entity class exclusion, but it only detected PHP 8 native attributes (`#[ORM\Entity]`, `#[Entity]`)
- PHPDoc-style `@Entity` / `@ORM\Entity` annotations (used via `doctrine/annotations`) were silently ignored, causing false positives
- Fix: extend `classHasEntityAttribute()` to also scan the leading trivia of the class's first token for a PHPDoc `@Entity` or `@ORM\Entity` annotation

## Test plan

- [ ] New `// OK` test cases in `TooManyMethodsInClassCheck.php` cover `@Entity`, `@ORM\Entity(...)`, and the abstract-class variant
- [ ] `TooManyMethodsInClassCheckTest` passes
- [ ] Existing native-attribute cases are unaffected

Fixes [SONARPHP-1866](https://sonarsource.atlassian.net/browse/SONARPHP-1866)
Community thread: https://community.sonarsource.com/t/php-rule-php-s1448-not-ignoring-entity-classes/180309

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SONARPHP-1866]: https://sonarsource.atlassian.net/browse/SONARPHP-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ