### PR TITLE
SONARPHP-1868 Replace backtracking-prone regex in NoAssertionInTestCheck with string matching

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/phpunit/NoAssertionInTestCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/phpunit/NoAssertionInTestCheck.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.php.checks.utils.CheckUtils;
@@ -43,7 +42,18 @@ import static org.sonar.php.tree.TreeUtils.hasAnnotationOrAttribute;
 public class NoAssertionInTestCheck extends PhpUnitCheck {
   private static final String MESSAGE = "Add at least one assertion to this test case.";
 
-  private static final Pattern ASSERTION_METHODS_PATTERN = Pattern.compile("(assert|verify|fail|pass|should|will|check|expect|validate|.*test).*");
+  private static final List<String> ASSERTION_METHOD_PREFIXES = Arrays.asList(
+    "assert",
+    "verify",
+    "fail",
+    "pass",
+    "should",
+    "will",
+    "check",
+    "expect",
+    "validate");
+  private static final List<String> ASSERTION_METHOD_INFIXES = Arrays.asList(
+    "test");
   private static final List<String> TEST_CONTROL_FUNCTIONS = Arrays.asList(
     "addtoassertioncount",
     "marktestskipped",
@@ -104,7 +114,8 @@ public class NoAssertionInTestCheck extends PhpUnitCheck {
         return false;
       }
 
-      return ASSERTION_METHODS_PATTERN.matcher(functionName).matches()
+      return ASSERTION_METHOD_PREFIXES.stream().anyMatch(functionName::startsWith)
+        || ASSERTION_METHOD_INFIXES.stream().anyMatch(functionName::contains)
         || TEST_CONTROL_FUNCTIONS.contains(functionName);
     }
 


### PR DESCRIPTION
## Summary

`NoAssertionInTestCheck` used a regex to decide whether a called function name "looks like" an assertion (so the S2699 "test has no assertion" check doesn't flag it):

```java
Pattern.compile("(assert|verify|fail|pass|should|will|check|expect|validate|.*test).*");
```

This triggered `java:S8786` (super-linear regex backtracking), which was driving the project's Reliability rating to C and failing the quality gate. The `.*test` alternation branch overlaps with the trailing `.*`, so on non-matching inputs the engine tries every split point — polynomial backtracking.

Since the pattern is only ever used with `Matcher.matches()`, it expresses nothing more than:

- **starts with** one of `assert`, `verify`, `fail`, `pass`, `should`, `will`, `check`, `expect`, `validate`, or
- **contains** `test`.

Rather than rewrite the regex to be backtracking-safe, this replaces it with plain string matching, which removes the regex entirely (so S8786 cannot apply), is clearer about intent, and is faster:

```java
return ASSERTION_METHOD_PREFIXES.stream().anyMatch(functionName::startsWith)
  || ASSERTION_METHOD_INFIXES.stream().anyMatch(functionName::contains)
  || TEST_CONTROL_FUNCTIONS.contains(functionName);
```

The prefix and infix vocabularies are declared as lists at the top of the class alongside the existing `TEST_CONTROL_FUNCTIONS`, so the matching terms live in one place and are easy to extend.

## Behaviour

Identical to before. `matches()` is anchored at both ends, so the literal alternatives were already prefix matches (`assertEquals` ✓, `xassert` ✗) and `.*test` was a substring match — exactly what `startsWith`/`contains` reproduce. Verified against the existing `NoAssertionInTestCheckTest` suite, including names that start with `test` (e.g. `testK`).

Closes [SONARPHP-1868](https://sonarsource.atlassian.net/browse/SONARPHP-1868)

[SONARPHP-1868]: https://sonarsource.atlassian.net/browse/SONARPHP-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ