### PR TITLE
SONARPHP-1871: php:S1185 False positive with method attributes

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/OverridingMethodSimplyCallParentCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/OverridingMethodSimplyCallParentCheck.java
@@ -77,6 +77,9 @@ public class OverridingMethodSimplyCallParentCheck extends PHPVisitorCheck {
   }
 
   private void checkMethod(MethodDeclarationTree method, ClassSymbol superClass) {
+    if (!method.attributeGroups().isEmpty()) {
+      return;
+    }
     if (method.body().is(Kind.BLOCK)) {
       BlockTree blockTree = (BlockTree) method.body();
 

--- a/php-checks/src/test/resources/checks/OverridingMethodSimplyCallParentCheck.php
+++ b/php-checks/src/test/resources/checks/OverridingMethodSimplyCallParentCheck.php
@@ -179,3 +179,15 @@ class AnotherG extends G
         parent::__construct($arg);
     }
 }
+
+//////////////////////////////////
+// shouldn't trigger if the overriding method declares an attribute
+
+abstract class BaseFoo {
+    public function getFoo(): string { return 'foo'; }
+}
+
+class Foo extends BaseFoo {
+    #[\Deprecated]
+    public function getFoo(): string { return parent::getFoo(); } // OK
+}


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fixes:**
  - Modified `OverridingMethodSimplyCallParentCheck` to ignore methods with attributes, preventing false positives for rule `S1185`.
  - Added test cases in `OverridingMethodSimplyCallParentCheck.php` to verify that methods with `#[Deprecated]` attributes no longer trigger the check.

<sub>This will update automatically on new commits.</sub>