### PR TITLE
SONARPHP-1880 Fix nullability annotations for SQ findings

### DIFF
--- a/php-frontend/src/main/java/org/sonar/php/filters/SuppressWarningFilter.java
+++ b/php-frontend/src/main/java/org/sonar/php/filters/SuppressWarningFilter.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import org.sonar.php.tree.impl.PHPTree;
 import org.sonar.plugins.php.api.tree.Tree;
 import org.sonar.plugins.php.api.tree.declaration.AttributeGroupTree;
@@ -105,7 +106,7 @@ public class SuppressWarningFilter extends PHPVisitorCheck implements PHPIssueFi
     }
   }
 
-  private static Set<Integer> computeLines(PHPTree phpTree, SyntaxToken startToken, SyntaxToken endToken) {
+  private static Set<Integer> computeLines(@Nullable PHPTree phpTree, SyntaxToken startToken, SyntaxToken endToken) {
     int startLine = Optional.ofNullable(phpTree)
       .map(PHPTree::getFirstToken)
       .map(SyntaxToken::line)

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/expression/ArrayAssignmentPatternElementTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/expression/ArrayAssignmentPatternElementTreeImpl.java
@@ -30,11 +30,13 @@ import org.sonar.plugins.php.api.visitors.VisitorCheck;
 public class ArrayAssignmentPatternElementTreeImpl extends PHPTree implements ArrayAssignmentPatternElementTree {
 
   private static final Kind KIND = Kind.ARRAY_ASSIGNMENT_PATTERN_ELEMENT;
+  @Nullable
   private final ExpressionTree key;
+  @Nullable
   private final InternalSyntaxToken doubleArrow;
   private final Tree variable;
 
-  public ArrayAssignmentPatternElementTreeImpl(ExpressionTree key, InternalSyntaxToken doubleArrow, Tree variable) {
+  public ArrayAssignmentPatternElementTreeImpl(@Nullable ExpressionTree key, @Nullable InternalSyntaxToken doubleArrow, Tree variable) {
     this.key = key;
     this.doubleArrow = doubleArrow;
     this.variable = variable;

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/TryStatementTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/TryStatementTreeImpl.java
@@ -41,7 +41,8 @@ public class TryStatementTreeImpl extends PHPTree implements TryStatementTree {
   @Nullable
   private final BlockTree finallyBlock;
 
-  public TryStatementTreeImpl(InternalSyntaxToken tryToken, BlockTree blockTree, List<CatchBlockTree> catchBlocks, @Nullable InternalSyntaxToken finallyToken, @Nullable BlockTree finallyBlock) {
+  public TryStatementTreeImpl(InternalSyntaxToken tryToken, BlockTree blockTree, List<CatchBlockTree> catchBlocks, @Nullable InternalSyntaxToken finallyToken,
+    @Nullable BlockTree finallyBlock) {
     this.tryToken = tryToken;
     this.block = blockTree;
     this.catchBlocks = catchBlocks;

--- a/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/TryStatementTreeImpl.java
+++ b/php-frontend/src/main/java/org/sonar/php/tree/impl/statement/TryStatementTreeImpl.java
@@ -36,10 +36,12 @@ public class TryStatementTreeImpl extends PHPTree implements TryStatementTree {
   private final InternalSyntaxToken tryToken;
   private final BlockTree block;
   private final List<CatchBlockTree> catchBlocks;
+  @Nullable
   private final InternalSyntaxToken finallyToken;
+  @Nullable
   private final BlockTree finallyBlock;
 
-  public TryStatementTreeImpl(InternalSyntaxToken tryToken, BlockTree blockTree, List<CatchBlockTree> catchBlocks, InternalSyntaxToken finallyToken, BlockTree finallyBlock) {
+  public TryStatementTreeImpl(InternalSyntaxToken tryToken, BlockTree blockTree, List<CatchBlockTree> catchBlocks, @Nullable InternalSyntaxToken finallyToken, @Nullable BlockTree finallyBlock) {
     this.tryToken = tryToken;
     this.block = blockTree;
     this.catchBlocks = catchBlocks;


### PR DESCRIPTION
## Summary
- Mark nullable parameters/fields where constructors intentionally accept null optional tree parts
- Align SuppressWarningFilter.computeLines with its null-safe implementation

## Tests
- ./gradlew :php-frontend:test --tests org.sonar.php.tree.impl.expression.ArrayAssignmentPatternElementTreeTest --tests org.sonar.php.tree.impl.statement.TryStatementTreeTest --tests org.sonar.php.filters.SuppressWarningFilterTest