### PR TITLE
SONARPHP-1889 Add null checks to prevent NPE and suppress warning

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/formatting/ControlStructureSpacingCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/formatting/ControlStructureSpacingCheck.java
@@ -111,7 +111,10 @@ public class ControlStructureSpacingCheck extends PHPSubscriptionCheck implement
     return isExactlyOneSpaceBetweenOrLineSplit(prevToken, token) && isExactlyOneSpaceBetweenOrLineSplit(token, nextToken);
   }
 
-  private static boolean isExactlyOneSpaceBetweenOrLineSplit(SyntaxToken leftToken, SyntaxToken rightToken) {
+  private static boolean isExactlyOneSpaceBetweenOrLineSplit(@Nullable SyntaxToken leftToken, @Nullable SyntaxToken rightToken) {
+    if (leftToken == null || rightToken == null) {
+      return true;
+    }
     return TokenUtils.getNbSpaceBetween(leftToken, rightToken) == 1 || !TokenUtils.isOnSameLine(leftToken, rightToken);
   }
 
@@ -164,7 +167,10 @@ public class ControlStructureSpacingCheck extends PHPSubscriptionCheck implement
   /**
    * Check that there is exactly one space between a control structure keyword and a opening parenthesis or curly brace.
    */
-  private void checkSpaceBetweenKeywordAndNextNode(SyntaxToken keyword, SyntaxToken nextToken) {
+  private void checkSpaceBetweenKeywordAndNextNode(@Nullable SyntaxToken keyword, @Nullable SyntaxToken nextToken) {
+    if (keyword == null || nextToken == null) {
+      return;
+    }
     if (TokenUtils.isType(nextToken, PHPPunctuator.LCURLYBRACE, PHPPunctuator.LPARENTHESIS) && TokenUtils.isOnSameLine(keyword, nextToken)) {
       int nbSpace = TokenUtils.getNbSpaceBetween(keyword, nextToken);
 

--- a/php-checks/src/main/java/org/sonar/php/checks/utils/TokenVisitor.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/utils/TokenVisitor.java
@@ -64,7 +64,11 @@ public class TokenVisitor extends PHPVisitorCheck {
       .orElse(null);
   }
 
-  public SyntaxToken prevToken(SyntaxToken token) {
+  @Nullable
+  public SyntaxToken prevToken(@Nullable SyntaxToken token) {
+    if (token == null) {
+      return null;
+    }
     for (int i = 0; i < tokens.size(); i++) {
       if (token.equals(tokens.get(i))) {
         if (i > 0) {
@@ -77,7 +81,11 @@ public class TokenVisitor extends PHPVisitorCheck {
     return null;
   }
 
-  public SyntaxToken nextToken(SyntaxToken token) {
+  @Nullable
+  public SyntaxToken nextToken(@Nullable SyntaxToken token) {
+    if (token == null) {
+      return null;
+    }
     for (int i = 0; i < tokens.size(); i++) {
       if (token.equals(tokens.get(i))) {
         if (i < tokens.size() - 1) {

--- a/php-checks/src/test/java/org/sonar/php/checks/utils/TokenVisitorTest.java
+++ b/php-checks/src/test/java/org/sonar/php/checks/utils/TokenVisitorTest.java
@@ -1,0 +1,84 @@
+/*
+ * SonarQube PHP Plugin
+ * Copyright (C) 2010-2026 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the Sonar Source-Available License Version 1, as published by SonarSource Sàrl.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the Sonar Source-Available License for more details.
+ *
+ * You should have received a copy of the Sonar Source-Available License
+ * along with this program; if not, see https://sonarsource.com/license/ssal/
+ */
+package org.sonar.php.checks.utils;
+
+import com.sonar.sslr.api.typed.ActionParser;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.php.parser.PHPLexicalGrammar;
+import org.sonar.php.parser.PHPParserBuilder;
+import org.sonar.plugins.php.api.tree.Tree;
+import org.sonar.plugins.php.api.tree.lexical.SyntaxToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenVisitorTest {
+
+  private final ActionParser<Tree> parser = PHPParserBuilder.createParser(PHPLexicalGrammar.TOP_STATEMENT);
+
+  @Test
+  void prevAndNextTokenNavigateAdjacentTokens() {
+    Tree tree = parser.parse("if ($a) { foo(); }");
+    TokenVisitor visitor = new TokenVisitor(tree);
+    List<SyntaxToken> tokens = TokenVisitor.tokens(tree);
+
+    SyntaxToken openParenthesis = tokens.get(1);
+    SyntaxToken variable = tokens.get(2);
+    SyntaxToken closeParenthesis = tokens.get(3);
+
+    assertThat(visitor.prevToken(variable)).isEqualTo(openParenthesis);
+    assertThat(visitor.nextToken(variable)).isEqualTo(closeParenthesis);
+  }
+
+  @Test
+  void prevAndNextTokenReturnNullAtTreeBoundaries() {
+    Tree tree = parser.parse("if ($a) { foo(); }");
+    TokenVisitor visitor = new TokenVisitor(tree);
+    List<SyntaxToken> tokens = TokenVisitor.tokens(tree);
+
+    SyntaxToken firstToken = tokens.get(0);
+    SyntaxToken lastToken = tokens.get(tokens.size() - 1);
+
+    assertThat(visitor.prevToken(firstToken)).isNull();
+    assertThat(visitor.nextToken(lastToken)).isNull();
+  }
+
+  @Test
+  void prevAndNextTokenReturnNullOnNullInput() {
+    Tree tree = parser.parse("if ($a) { foo(); }");
+    TokenVisitor visitor = new TokenVisitor(tree);
+
+    assertThat(visitor.prevToken(null)).isNull();
+    assertThat(visitor.nextToken(null)).isNull();
+  }
+
+  @Test
+  void firstKeywordFindsLeadingKeyword() {
+    Tree tree = parser.parse("if ($a) { foo(); }");
+    TokenVisitor visitor = new TokenVisitor(tree);
+
+    assertThat(visitor.firstKeyword().text()).isEqualTo("if");
+  }
+
+  @Test
+  void firstKeywordReturnsNullWhenNoKeywordPresent() {
+    Tree tree = parser.parse("$a = 1;");
+    TokenVisitor visitor = new TokenVisitor(tree);
+
+    assertThat(visitor.firstKeyword()).isNull();
+  }
+}

--- a/php-checks/src/test/java/org/sonar/php/checks/utils/TokenVisitorTest.java
+++ b/php-checks/src/test/java/org/sonar/php/checks/utils/TokenVisitorTest.java
@@ -81,4 +81,5 @@ class TokenVisitorTest {
 
     assertThat(visitor.firstKeyword()).isNull();
   }
+
 }

--- a/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
+++ b/php-frontend/src/main/java/org/sonar/php/parser/PHPGrammar.java
@@ -1569,6 +1569,8 @@ public class PHPGrammar {
       f.yieldExpression(b.token(YIELD)));
   }
 
+  // Seemingly infinite recursion is correctly handled by SSLR
+  @SuppressWarnings("javabugs:S2190")
   public ParenthesisedExpressionTree PARENTHESIZED_EXPRESSION() {
     return b.<ParenthesisedExpressionTree>nonterminal(Kind.PARENTHESISED_EXPRESSION).is(
       f.parenthesizedExpression(


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **Null safety improvements:**
    - Added `@Nullable` annotations and explicit null checks to `TokenVisitor` methods `prevToken` and `nextToken`.
    - Updated `ControlStructureSpacingCheck` helper methods to handle null tokens gracefully.
- **Code maintenance:**
    - Suppressed unnecessary recursion warning in `PHPGrammar` with `@SuppressWarnings`.
- **Testing:**
    - Added `TokenVisitorTest` to verify token navigation logic and edge cases including null inputs.


<sub>This will update automatically on new commits.</sub>