### PR TITLE
SONARPHP-1890 Improve performance of CommentedOutCodeCheck and HardCodedIpAddressCheck

### DIFF
--- a/php-checks/src/main/java/org/sonar/php/checks/CommentedOutCodeCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/CommentedOutCodeCheck.java
@@ -104,8 +104,7 @@ public class CommentedOutCodeCheck extends PHPVisitorCheck {
   }
 
   private static boolean isParsableCode(String possibleCode) {
-    // empty comment should not be commented out code
-    if (MULTIPLE_LINEBREAKS.matcher(possibleCode).replaceAll("").trim().isEmpty()) {
+    if (!couldBeCode(possibleCode)) {
       return false;
     }
 
@@ -138,6 +137,14 @@ public class CommentedOutCodeCheck extends PHPVisitorCheck {
     }
 
     return false;
+  }
+
+  /**
+   * Pre-filtering to avoid starting the parser on most strings.
+   * The rules we parse for should contain at least one of the below according to the grammar.
+   */
+  private static boolean couldBeCode(String possibleCode) {
+    return possibleCode.indexOf('{') != -1 || possibleCode.indexOf(';') != -1 || possibleCode.contains("?>");
   }
 
 }

--- a/php-checks/src/main/java/org/sonar/php/checks/HardCodedIpAddressCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/HardCodedIpAddressCheck.java
@@ -91,7 +91,7 @@ public class HardCodedIpAddressCheck extends PHPVisitorCheck {
   }
 
   private static boolean couldBeIpAddress(String value) {
-    // An IPv4 cannot start with a dot thus the ">". A v6 one cant start with ":".
+    // An IPv4 cannot start with a dot thus the ">". A v6 one can start with ":".
     return value.indexOf('.') > 0 || value.indexOf(':') >= 0;
   }
 

--- a/php-checks/src/main/java/org/sonar/php/checks/HardCodedIpAddressCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/HardCodedIpAddressCheck.java
@@ -91,6 +91,7 @@ public class HardCodedIpAddressCheck extends PHPVisitorCheck {
   }
 
   private static boolean couldBeIpAddress(String value) {
+    // An IPv4 cannot start with a dot thus the ">". A v6 one cant start with ":".
     return value.indexOf('.') > 0 || value.indexOf(':') >= 0;
   }
 

--- a/php-checks/src/main/java/org/sonar/php/checks/HardCodedIpAddressCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/HardCodedIpAddressCheck.java
@@ -90,7 +90,7 @@ public class HardCodedIpAddressCheck extends PHPVisitorCheck {
     super.visitLiteral(tree);
   }
 
-  private boolean couldBeIpAddress(String value) {
+  private static boolean couldBeIpAddress(String value) {
     return value.indexOf('.') > 0 || value.indexOf(':') >= 0;
   }
 

--- a/php-checks/src/main/java/org/sonar/php/checks/HardCodedIpAddressCheck.java
+++ b/php-checks/src/main/java/org/sonar/php/checks/HardCodedIpAddressCheck.java
@@ -74,8 +74,13 @@ public class HardCodedIpAddressCheck extends PHPVisitorCheck {
   public void visitLiteral(LiteralTree tree) {
     if (tree.is(Tree.Kind.REGULAR_STRING_LITERAL)) {
       String literalValue = trimQuotes(tree.value());
+
+      if (!couldBeIpAddress(literalValue)) {
+        return;
+      }
+
       Matcher matcher = IP_PATTERN.matcher(literalValue);
-      if (matcher.find() && matcher.start() == 0) {
+      if (matcher.lookingAt()) {
         String ip = matcher.group("ip");
         if (isSensitive(ip)) {
           context().newIssue(this, tree, MESSAGE);
@@ -83,6 +88,10 @@ public class HardCodedIpAddressCheck extends PHPVisitorCheck {
       }
     }
     super.visitLiteral(tree);
+  }
+
+  private boolean couldBeIpAddress(String value) {
+    return value.indexOf('.') > 0 || value.indexOf(':') >= 0;
   }
 
   private static boolean isSensitive(String ip) {

--- a/php-checks/src/test/java/org/sonar/php/checks/CommentedOutCodeCheckTest.java
+++ b/php-checks/src/test/java/org/sonar/php/checks/CommentedOutCodeCheckTest.java
@@ -44,7 +44,8 @@ class CommentedOutCodeCheckTest {
       newIssue(85),
       newIssue(87),
       newIssue(93),
-      newIssue(97));
+      newIssue(97),
+      newIssue(132));
 
     PHPCheckTest.check(CHECK, TestUtils.getCheckFile("CommentedOutCodeCheck.php"), issues);
   }

--- a/php-checks/src/test/resources/checks/CommentedOutCodeCheck.php
+++ b/php-checks/src/test/resources/checks/CommentedOutCodeCheck.php
@@ -128,3 +128,5 @@ $helper->log('Set header/footer');
  *
  * @return void
  */
+
+/* $foo = 1 ?><?php */


### PR DESCRIPTION
Noticed that these two checks are quite expensive on big projects. The pre-filtering should keep semantics. Impact on Moodle:
```
  - CommentedOutCodeCheck: 65.5s → 11.3s
  - HardCodedIpAddressCheck: 8.9s → 1.7s
```

We could probably be even more aggressive in pre-filtering, but these are quick wins we can already take. 

----
## Summary by Gitar

- **Performance optimizations:**
    - Added `couldBeCode` pre-filter in `CommentedOutCodeCheck` to avoid unnecessary parsing operations.
    - Implemented `couldBeIpAddress` check and switched to `matcher.lookingAt()` in `HardCodedIpAddressCheck` to speed up string matching.

<sub>This will update automatically on new commits.</sub>