### PR TITLE
SONARPHP-1895 Renovate should automatically rewrite lockfiles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,12 @@
     "before 4am on Monday"
   ],
   "rebaseWhen": "conflicted",
+  "cloneSubmodules": true,
+  "cloneSubmodulesFilter": [
+    "build-logic/common"
+  ],
   "enabledManagers": ["gradle", "gradle-wrapper", "github-actions", "regex", "git-submodules"],
+  "postUpdateOptions": ["gradleLockfileUpdate"],
   "gradle": {
     "enabled": true
   },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
   "cloneSubmodulesFilter": [
     "build-logic/common"
   ],
-  "enabledManagers": ["gradle", "gradle-wrapper", "github-actions", "regex", "git-submodules"],
+  "enabledManagers": ["gradle", "gradle-wrapper", "github-actions", "custom.regex", "git-submodules"],
   "postUpdateOptions": ["gradleLockfileUpdate"],
   "gradle": {
     "enabled": true


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration:**
    - Enabled automatic Gradle lockfile updates via `postUpdateOptions` in `renovate.json`
    - Configured git submodules cloning behavior and filters in `renovate.json`

<sub>This will update automatically on new commits.</sub>