### PR TITLE
SONARPHP-1917 Update build logic and target Java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Gradle lock files pin dependency versions to ensure reproducible builds. When de
 To run integration tests, you will need to create a properties file like the one shown below, and set its location in an environment variable named `ORCHESTRATOR_CONFIG_URL`.
 ```properties
 # version of SonarQube server
-sonar.runtimeVersion=9.9
+sonar.runtimeVersion=LATEST_RELEASE
 ```
 Before running any of the integration tests make sure the submodules are checked out:
 ```shell

--- a/its/README.md
+++ b/its/README.md
@@ -2,7 +2,7 @@
 
 # Prerequisites
 
-* SonarQube ITs need Java 17 to run
+* SonarQube ITs need Java 21 to run
 
 # First time configuration
 


### PR DESCRIPTION
## Summary

- update `build-logic/common` from `f298403` to `8eea976`
- target Java 21 through the shared Java conventions, following the removal of Java 17 as a supported analysis runtime
- upgrade the build-time Jackson dependency from 2.22.1 to 2.22.2 to resolve the reported dependency risk

The generated analyzer manifest now declares `Jre-Min-Version: 21`. This also prepares the test modules for scanner-engine 13.7 and later.

## Validation

- `./gradlew build -x integrationTest --no-daemon`
- verified `com.fasterxml.jackson.core:jackson-databind` resolves to 2.22.2 in the build-logic runtime classpath
- verified the analyzer artifact targets Java 21 (class-file version 65)