### PR TITLE
SONARPHP-1919 Enable fix-version automation on PR merge

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -26,3 +26,4 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
           jira-token: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+          fix-version: autodetect-lowest


### PR DESCRIPTION
Enables the `fix-version` input on the `PullRequestClosed` GitHub Action so that merging a PR automatically sets the linked Jira ticket's fixVersion to the lowest unreleased version.

This mirrors the automation already enabled in sonar-java, SonarJS, sonar-cobol, sonar-dotnet-enterprise, sonar-python-enterprise, sonar-xml, sonar-flex, sonar-html, sonar-cpp, and sonar-plsql.